### PR TITLE
LIBITD-1533. Initial implementation of "filename only match"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,45 @@ is a directory, every file in that directory will be loaded.
 
 ### Finding perfect matches
 
+A perfect match between an accession and a restore is where:
+
+* The MD5 values match (accession.md5 == restore.md5)
+* The filenames match (accession.filename == restore.filename)
+* The file sizes match (accession.bytes == restore.bytes)
+
 To find new perfect matches for a particular batch of accessions:
 
 ```
 > python3 -m patsy --database <SQLITE_DATABASE_FILE> find_perfect_matches --batch <BATCH>
+```
 
 where <SQLITE_DATABASE_FILE> is the path to the SQLite database, and <BATCH> is
 an (optional) batch name (corresponding to the "batch" field in the accession).
 
-If the "--batch" parameter is not provides, all accessions will be searched.
+If the "--batch" parameter is not provided, all accessions will be searched.
 
+### Finding altered MD5 matches
+
+An altered MD5 match between an accession and a restore is where:
+
+* The MD5 values do not match (accession.md5 != restore.md5)
+* The filenames match (accession.filename == restore.filename)
+* The file sizes match (accession.bytes == restore.bytes)
+
+An altered MD5 match indicates a *possible* match between an accession to a
+restore, where there might be data corruption.
+
+To find new altered MD5 matches for a particular batch of accessions:
 
 ```
+> python3 -m patsy --database <SQLITE_DATABASE_FILE> find_altered_md5_matches --batch <BATCH>
+```
+
+where <SQLITE_DATABASE_FILE> is the path to the SQLite database, and <BATCH> is
+an (optional) batch name (corresponding to the "batch" field in the accession).
+
+If the "--batch" parameter is not provided, all accessions will be searched.
+
 ## Accession Records
 
 Accession records represent the "canonical" information about an asset. These

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Command-line client for preservation asset tracking system (PATSy)
 
-## Prerequsites
+## Prerequisites
 
 * Python 3.7
 * pip
@@ -116,6 +116,29 @@ To find new altered MD5 matches for a particular batch of accessions:
 
 ```
 > python3 -m patsy --database <SQLITE_DATABASE_FILE> find_altered_md5_matches --batch <BATCH>
+```
+
+where <SQLITE_DATABASE_FILE> is the path to the SQLite database, and <BATCH> is
+an (optional) batch name (corresponding to the "batch" field in the accession).
+
+If the "--batch" parameter is not provided, all accessions will be searched.
+
+### Finding filename only matches
+
+A filename only match between an accession and a restore is where:
+
+* The MD5 values do not match (accession.md5 != restore.md5)
+* The file sizes do not match (accession.bytes != restore.bytes)
+* The filenames match (accession.filename == restore.filename)
+
+A filename match indicates a *possible* match between an accession to a
+restore, where there might be data corruption, or just a simple coincidence
+of filename.
+
+To find new filename only matches for a particular batch of accessions:
+
+```
+> python3 -m patsy --database <SQLITE_DATABASE_FILE> find_filename_only_matches --batch <BATCH>
 ```
 
 where <SQLITE_DATABASE_FILE> is the path to the SQLite database, and <BATCH> is

--- a/patsy/__main__.py
+++ b/patsy/__main__.py
@@ -6,6 +6,7 @@ from . import version
 from .accession import AccessionCsvLoader
 from .database import create_schema
 from .perfect_matches import find_perfect_matches_command
+from .altered_md5_matches import find_altered_md5_matches_command
 from .database import use_database_file
 from .restore import RestoreCsvLoader
 from .utils import print_header
@@ -66,12 +67,24 @@ def get_args():
         help='Source of restores to load'
         )
 
-    # create the parser for the "load_accessions" command
+    # create the parser for the "find_perfect_matches" command
     find_perfect_matches_subcommand = subparsers.add_parser(
         'find_perfect_matches',
         help='Scans accession and restore records looking for perfect matches'
         )
     find_perfect_matches_subcommand.add_argument(
+        '-b', '--batch',
+        action='store',
+        default=None,
+        help='Batchname to query'
+        )
+
+    # create the parser for the "find_altered_md5_matches" command
+    find_altered_md5_matches_subcommand = subparsers.add_parser(
+        'find_altered_md5_matches',
+        help='Scans accession and restore records looking for altered MD5 matches'
+        )
+    find_altered_md5_matches_subcommand.add_argument(
         '-b', '--batch',
         action='store',
         default=None,
@@ -110,6 +123,14 @@ def main():
         use_database_file(args.database)
         matches_found = find_perfect_matches_command(args.batch, PrintProgressNotifier())
         print("-----Perfect Matches ----")
+        for match in matches_found:
+            print(match)
+        print(f"{len(matches_found)} new matches found")
+
+    elif args.cmd == 'find_altered_md5_matches':
+        use_database_file(args.database)
+        matches_found = find_altered_md5_matches_command(args.batch, PrintProgressNotifier())
+        print("-----Altered MD5 Matches ----")
         for match in matches_found:
             print(match)
         print(f"{len(matches_found)} new matches found")

--- a/patsy/__main__.py
+++ b/patsy/__main__.py
@@ -7,6 +7,7 @@ from .accession import AccessionCsvLoader
 from .database import create_schema
 from .perfect_matches import find_perfect_matches_command
 from .altered_md5_matches import find_altered_md5_matches_command
+from .filename_only_matches import find_filename_only_matches_command
 from .database import use_database_file
 from .restore import RestoreCsvLoader
 from .utils import print_header
@@ -91,6 +92,18 @@ def get_args():
         help='Batchname to query'
         )
 
+    # create the parser for the "find_filename_only_matches" command
+    find_filename_only_matches_subcommand = subparsers.add_parser(
+        'find_filename_only_matches',
+        help='Scans accession and restore records looking for filename only matches'
+        )
+    find_filename_only_matches_subcommand.add_argument(
+        '-b', '--batch',
+        action='store',
+        default=None,
+        help='Batchname to query'
+        )
+
     return parser.parse_args()
 
 
@@ -131,6 +144,14 @@ def main():
         use_database_file(args.database)
         matches_found = find_altered_md5_matches_command(args.batch, PrintProgressNotifier())
         print("-----Altered MD5 Matches ----")
+        for match in matches_found:
+            print(match)
+        print(f"{len(matches_found)} new matches found")
+
+    elif args.cmd == 'find_filename_only_matches':
+        use_database_file(args.database)
+        matches_found = find_filename_only_matches_command(args.batch, PrintProgressNotifier())
+        print("-----Filename Only Matches ----")
         for match in matches_found:
             print(match)
         print(f"{len(matches_found)} new matches found")

--- a/patsy/altered_md5_matches.py
+++ b/patsy/altered_md5_matches.py
@@ -1,12 +1,12 @@
 from .database import Session
-from .model import Accession, Restore
+from .model import Restore
 from .progress_notifier import ProgressNotifier
 from .utils import get_accessions
 
 
-def find_perfect_matches_command(batch=None, progress_notifier=ProgressNotifier()):
+def find_altered_md5_matches_command(batch=None, progress_notifier=ProgressNotifier()):
     """
-    Called by the CLI to perform the "find_perfect_matches" command.
+    Called by the CLI to perform the "find_altered_md5_matches" command.
     :param batch: The name of the batch to limit the search to. Defaults to None,
                   which means all accessions will be searched.
     :param progress_notifier: A ProgressNotifier to report individual file loads
@@ -20,14 +20,15 @@ def find_perfect_matches_command(batch=None, progress_notifier=ProgressNotifier(
     accessions = get_accessions(session, batch)
     progress_notifier.notify(f"Querying {accessions.count()} accession records.")
 
-    new_matches_found = find_perfect_matches(session, accessions)
+    new_matches_found = find_altered_md5_matches(session, accessions)
     session.commit()
     return new_matches_found
 
 
-def find_perfect_matches(session, accessions):
+def find_altered_md5_matches(session, accessions):
     """
-    Queries the database and adds new perfect matches for the given accessions.
+    Queries the database and adds new altered MD5 matches for the given
+    accessions.
 
     Note: The method will update the database if new matches are found
 
@@ -38,16 +39,13 @@ def find_perfect_matches(session, accessions):
     """
     new_matches_found = []
     for accession in accessions:
-        accession_md5 = accession.md5
-
         restores = session.query(Restore)\
-                          .filter(Restore.md5 == accession_md5,
-                                  Restore.filename == accession.filename,
+                          .filter(Restore.filename == accession.filename,
                                   Restore.bytes == accession.bytes)
 
         for restore in restores:
-            if restore not in accession.perfect_matches:
-                accession.perfect_matches.append(restore)
+            if restore.md5 != accession.md5 and restore not in accession.altered_md5_matches:
+                accession.altered_md5_matches.append(restore)
                 new_matches_found.append(f"{accession}:{restore}")
 
     return new_matches_found

--- a/patsy/filename_only_matches.py
+++ b/patsy/filename_only_matches.py
@@ -1,0 +1,52 @@
+from .database import Session
+from .model import Restore
+from .progress_notifier import ProgressNotifier
+from .utils import get_accessions
+
+
+def find_filename_only_matches_command(batch=None, progress_notifier=ProgressNotifier()):
+    """
+    Called by the CLI to perform the "find_filename_only_matches" command.
+    :param batch: The name of the batch to limit the search to. Defaults to None,
+                  which means all accessions will be searched.
+    :param progress_notifier: A ProgressNotifier to report individual file loads
+                              and results. Defaults to ProgressNotifier, which
+                              is a no-op
+    :return: an array containing a description of the new matches that were
+             found
+    """
+    session = Session()
+
+    accessions = get_accessions(session, batch)
+    progress_notifier.notify(f"Querying {accessions.count()} accession records.")
+
+    new_matches_found = find_filename_only_matches(session, accessions)
+    session.commit()
+    return new_matches_found
+
+
+def find_filename_only_matches(session, accessions):
+    """
+    Queries the database and adds new filename only matches for the given
+    accessions.
+
+    Note: The method will update the database if new matches are found
+
+    :param session: the Session in which to perform the query
+    :param accessions: the list of accessions use for the search
+    :return: an array containing a description of the new matches that were
+             found
+    """
+    new_matches_found = []
+    for accession in accessions:
+        restores = session.query(Restore)\
+                          .filter(Restore.filename == accession.filename)
+
+        for restore in restores:
+            if restore.md5 != accession.md5 and\
+               restore.bytes != accession.bytes and\
+               restore not in accession.filename_only_matches:
+                accession.filename_only_matches.append(restore)
+                new_matches_found.append(f"{accession}:{restore}")
+
+    return new_matches_found

--- a/patsy/model.py
+++ b/patsy/model.py
@@ -19,6 +19,13 @@ altered_md5_matches_table = Table('altered_md5_matches', Base.metadata,
                                   Column('restore_id', Integer, ForeignKey('restores.id'))
                                   )
 
+# Many-to-many relationship between accessions and restores where the filename
+# is the same, but the MD5 checksum and bytes are different
+filename_only_matches_table = Table('filename_only_matches', Base.metadata,
+                                    Column('accession_id', Integer, ForeignKey('accessions.id')),
+                                    Column('restore_id', Integer, ForeignKey('restores.id'))
+                                    )
+
 
 class Accession(Base):
     """
@@ -38,6 +45,8 @@ class Accession(Base):
     md5 = Column(String)
     perfect_matches = relationship("Restore", secondary=perfect_matches_table, back_populates="perfect_matches")
     altered_md5_matches = relationship("Restore", secondary=altered_md5_matches_table, back_populates="altered_md5_matches")
+    filename_only_matches = relationship("Restore", secondary=filename_only_matches_table,
+                                         back_populates="filename_only_matches")
 
     def __repr__(self):
         return f"<Accession(id='{self.id}', batch='{self.batch}', relpath='{self.relpath}'>"
@@ -60,6 +69,8 @@ class Restore(Base):
     bytes = Column(Integer)
     perfect_matches = relationship("Accession", secondary=perfect_matches_table, back_populates="perfect_matches")
     altered_md5_matches = relationship("Accession", secondary=altered_md5_matches_table, back_populates="altered_md5_matches")
+    filename_only_matches = relationship("Accession", secondary=filename_only_matches_table,
+                                         back_populates="filename_only_matches")
 
     def __repr__(self):
         return f"<Restore(id='{self.id}', filepath='{self.filepath}'>"

--- a/patsy/model.py
+++ b/patsy/model.py
@@ -10,7 +10,14 @@ Base = declarative_base()
 perfect_matches_table = Table('perfect_matches', Base.metadata,
                               Column('accession_id', Integer, ForeignKey('accessions.id')),
                               Column('restore_id', Integer, ForeignKey('restores.id'))
-                             )
+                              )
+
+# Many-to-many relationship between accessions and restores where filename and bytes
+# are the same, but the MD5 checksum is different
+altered_md5_matches_table = Table('altered_md5_matches', Base.metadata,
+                                  Column('accession_id', Integer, ForeignKey('accessions.id')),
+                                  Column('restore_id', Integer, ForeignKey('restores.id'))
+                                  )
 
 
 class Accession(Base):
@@ -30,6 +37,7 @@ class Accession(Base):
     relpath = Column(String)
     md5 = Column(String)
     perfect_matches = relationship("Restore", secondary=perfect_matches_table, back_populates="perfect_matches")
+    altered_md5_matches = relationship("Restore", secondary=altered_md5_matches_table, back_populates="altered_md5_matches")
 
     def __repr__(self):
         return f"<Accession(id='{self.id}', batch='{self.batch}', relpath='{self.relpath}'>"
@@ -51,6 +59,7 @@ class Restore(Base):
     filepath = Column(String)
     bytes = Column(Integer)
     perfect_matches = relationship("Accession", secondary=perfect_matches_table, back_populates="perfect_matches")
+    altered_md5_matches = relationship("Accession", secondary=altered_md5_matches_table, back_populates="altered_md5_matches")
 
     def __repr__(self):
         return f"<Restore(id='{self.id}', filepath='{self.filepath}'>"

--- a/patsy/utils.py
+++ b/patsy/utils.py
@@ -2,47 +2,64 @@ import csv
 import hashlib
 import os
 import sys
+from .model import Accession
 
 
-def calculate_md5(path):
+def get_accessions(session, batch=None):
     """
-    Calclulate and return the object's md5 hash.
-    """
-    hash = hashlib.md5()
-    with open(path, 'rb') as f:
-        while True:
-            data = f.read(8192)
-            if not data:
-                break
-            else:
-                hash.update(data)
-    return hash.hexdigest()
+    Queries the database for a list of accessions
 
+    :param session: the Session in which to perform the query
+    :param batch: The name of the batch to limit the search to. Defaults to None,
+                  which means all accessions will be returned.
+    :return: a Query object representing the list of accessions
+    """
+    if batch is None:
+        accessions = session.query(Accession)
+    else:
+        accessions = session.query(Accession).filter(Accession.batch == batch)
 
-def get_common_root(path):
-    """
-    Return the root path common to all files in the dirlist.
-    Assumes that the dirlist is a csv with paths in the 2nd column.
-    """
-    with open(path) as handle:
-        reader = csv.reader(handle)
-        all_paths = [row[1] for row in reader]
-        if all_paths:
-            return os.path.commonpath(all_paths)
-        else:
-            return None
+    return accessions
 
-
-def human_readable(bytes):
-    """
-    Return a human-readable representation of the provided number of bytes.
-    """
-    for n, label in enumerate(['bytes', 'KiB', 'MiB', 'GiB', 'TiB']):
-        value = bytes / (1024 ** n)
-        if value < 1024:
-            return f'{round(value, 2)} {label}'
-        else:
-            continue
+# def calculate_md5(path):
+#     """
+#     Calclulate and return the object's md5 hash.
+#     """
+#     hash = hashlib.md5()
+#     with open(path, 'rb') as f:
+#         while True:
+#             data = f.read(8192)
+#             if not data:
+#                 break
+#             else:
+#                 hash.update(data)
+#     return hash.hexdigest()
+#
+#
+# def get_common_root(path):
+#     """
+#     Return the root path common to all files in the dirlist.
+#     Assumes that the dirlist is a csv with paths in the 2nd column.
+#     """
+#     with open(path) as handle:
+#         reader = csv.reader(handle)
+#         all_paths = [row[1] for row in reader]
+#         if all_paths:
+#             return os.path.commonpath(all_paths)
+#         else:
+#             return None
+#
+#
+# def human_readable(bytes):
+#     """
+#     Return a human-readable representation of the provided number of bytes.
+#     """
+#     for n, label in enumerate(['bytes', 'KiB', 'MiB', 'GiB', 'TiB']):
+#         value = bytes / (1024 ** n)
+#         if value < 1024:
+#             return f'{round(value, 2)} {label}'
+#         else:
+#             continue
 
 
 def print_header():

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -10,3 +10,17 @@ File has been modified to include a "relpath" path consisting of
 ## sample_data/restores/LIBDCR_Archive031.csv
 
 Copied from "patsy-data/data/restores/LIBRDCRProjectsShare-md5sum/nfs.isip01.nas.umd.edu_ifs_data_LIBR-Archives-Projects-Export_DCR_Projects_Archive031 Date 03202014_work_scan.csv"
+
+## sample_data/accessions/test_altered_md5_accessions.csv
+
+Accession data for testing "altered MD5" matches. There are 5 records, each
+of which has an "altered md5" match with one of the restore records in
+"sample_data/restores/test_altered_md5_restores.csv"
+
+## sample_data/restores/test_altered_md5_restores.csv
+
+Restore data for testing "altered MD5" matches. There are 5 records, each
+of which has MD5 of the form "MD5_ALTERED_<NUMBER>" that is purposely different
+from an accession record in
+"sample_data/accessions/test_altered_md5_accessions.csv", but with the same
+filename and file size.

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -24,3 +24,17 @@ of which has MD5 of the form "MD5_ALTERED_<NUMBER>" that is purposely different
 from an accession record in
 "sample_data/accessions/test_altered_md5_accessions.csv", but with the same
 filename and file size.
+
+## sample_data/accessions/test_filename_only_accessions.csv
+
+Accession data for testing "filename only" matches. There are 5 records, each
+of which has a "filename_only" match with one of the restore records in
+"sample_data/restores/test_filename_only_restores.csv"
+
+## sample_data/restores/test_filename_only_restores.csv
+
+Restore data for testing "filename only" matches. There are 5 records, each
+of which has MD5 of the form "MD5_FILENAME_ONLY_<NUMBER>" that is purposely
+different from an accession record in
+"sample_data/accessions/test_filename_only_accessions.csv" as well as a
+different file size, but with the same filename.

--- a/sample_data/accessions/test_altered_md5_accessions.csv
+++ b/sample_data/accessions/test_altered_md5_accessions.csv
@@ -1,0 +1,6 @@
+batch,sourcefile,sourceline,filename,bytes,timestamp,md5,relpath
+AlteredMD5Batch,AlteredMD5_2014-03-13_DPIdetails.txt,1,altered_md5_test_file1,2327511878,Fri Apr 26 15:52:37 EDT 2013,2f90e976c036856ece60dd7c536cc6c9,test/altered_md5_test_file1
+AlteredMD5Batch,AlteredMD5_2014-03-13_DPIdetails.txt,2,altered_md5_test_file2,393958590,Mon Apr 29 10:28:56 EDT 2013,66ab658c0675fc72ca6b42e4cb8f66a4,test/altered_md5_test_file2
+AlteredMD5Batch,AlteredMD5_2014-03-13_DPIdetails.txt,3,altered_md5_test_file3,2303286470,Mon Apr 29 12:21:30 EDT 2013,037feb7a305fae37707ed1c12de72080,test/altered_md5_test_file3
+AlteredMD5Batch,AlteredMD5_2014-03-13_DPIdetails.txt,4,altered_md5_test_file4,2315614406,Tue May 07 11:17:44 EDT 2013,d3c736d3f075e54d7d5c4235778935db,test/altered_md5_test_file4
+AlteredMD5Batch,AlteredMD5_2014-03-13_DPIdetails.txt,5,altered_md5_test_file5,2325970118,Mon Apr 29 16:24:24 EDT 2013,5b06bfd1e8921a2245784fc2ef246927,test/altered_md5_test_file5

--- a/sample_data/accessions/test_filename_only_accessions.csv
+++ b/sample_data/accessions/test_filename_only_accessions.csv
@@ -1,0 +1,6 @@
+batch,sourcefile,sourceline,filename,bytes,timestamp,md5,relpath
+FilenameOnlyBatch,FilenameOnly_2014-03-13_DPIdetails.txt,1,filename_only_test_file1,98765,Fri Apr 26 15:52:37 EDT 2013,2f90e976c036856ece60dd7c536cc6c9,test/filename_only_test_file1
+FilenameOnlyBatch,FilenameOnly_2014-03-13_DPIdetails.txt,2,filename_only_test_file2,98765,Mon Apr 29 10:28:56 EDT 2013,66ab658c0675fc72ca6b42e4cb8f66a4,test/filename_only_test_file2
+FilenameOnlyBatch,FilenameOnly_2014-03-13_DPIdetails.txt,3,filename_only_test_file3,98765,Mon Apr 29 12:21:30 EDT 2013,037feb7a305fae37707ed1c12de72080,test/filename_only_test_file3
+FilenameOnlyBatch,FilenameOnly_2014-03-13_DPIdetails.txt,4,filename_only_test_file4,98765,Tue May 07 11:17:44 EDT 2013,d3c736d3f075e54d7d5c4235778935db,test/filename_only_test_file4
+FilenameOnlyBatch,FilenameOnly_2014-03-13_DPIdetails.txt,5,filename_only_test_file5,98765,Mon Apr 29 16:24:24 EDT 2013,5b06bfd1e8921a2245784fc2ef246927,test/filename_only_test_file5

--- a/sample_data/restores/test_altered_md5_restores.csv
+++ b/sample_data/restores/test_altered_md5_restores.csv
@@ -1,0 +1,5 @@
+MD5_ALTERED_1,/libr/archives/projectsexport/DCR_Projects_AlteredMD5 Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/altered_md5_test_file1,altered_md5_test_file1,2327511878
+MD5_ALTERED_2,/libr/archives/projectsexport/DCR_Projects_AlteredMD5 Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/altered_md5_test_file2,altered_md5_test_file2,393958590
+MD5_ALTERED_3,/libr/archives/projectsexport/DCR_Projects_AlteredMD5 Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/altered_md5_test_file3,altered_md5_test_file3,2303286470
+MD5_ALTERED_4,/libr/archives/projectsexport/DCR_Projects_AlteredMD5 Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/altered_md5_test_file4,altered_md5_test_file4,2315614406
+MD5_ALTERED_5,/libr/archives/projectsexport/DCR_Projects_AlteredMD5 Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/altered_md5_test_file5,altered_md5_test_file5,2325970118

--- a/sample_data/restores/test_filename_only_restores.csv
+++ b/sample_data/restores/test_filename_only_restores.csv
@@ -1,0 +1,5 @@
+MD5_FILENAME_ONLY_1,/libr/archives/projectsexport/DCR_Projects_FilenameOnly Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/filename_only_test_file1,filename_only_test_file1,12345
+MD5_FILENAME_ONLY_2,/libr/archives/projectsexport/DCR_Projects_FilenameOnly Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/filename_only_test_file2,filename_only_test_file2,12345
+MD5_FILENAME_ONLY_3,/libr/archives/projectsexport/DCR_Projects_FilenameOnly Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/filename_only_test_file3,filename_only_test_file3,12345
+MD5_FILENAME_ONLY_4,/libr/archives/projectsexport/DCR_Projects_FilenameOnly Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/filename_only_test_file4,filename_only_test_file4,12345
+MD5_FILENAME_ONLY_5,/libr/archives/projectsexport/DCR_Projects_FilenameOnly Date 03202014/DCR Projects/Archive/NOVEMBER/bcast/filename_only_test_file5,filename_only_test_file5,12345

--- a/tests/test_altered_md5s.py
+++ b/tests/test_altered_md5s.py
@@ -1,0 +1,197 @@
+import patsy.database
+from sqlalchemy import create_engine
+from patsy.model import Base
+from patsy.perfect_matches import find_perfect_matches
+from patsy.altered_md5_matches import find_altered_md5_matches
+import unittest
+from patsy.model import Accession
+from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match
+
+Session = patsy.database.Session
+
+
+class TestAlteredMd5sMatches(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine('sqlite:///:memory:')
+        Session.configure(bind=engine)
+        Base.metadata.create_all(engine)
+
+    def test_no_altered_md5_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = RestoreBuilder().build()
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        # Verify that MD5 checksums and filenames are not equal
+        self.assertNotEqual(accession.md5, restore.md5)
+        self.assertNotEqual(accession.filename, restore.filename)
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+
+        # No perfect match should be found
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(0, len(accession.altered_md5_matches))
+        self.assertEqual(0, len(restore.altered_md5_matches))
+
+    def test_one_altered_md5_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'altered_md5'
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        self.assertEqual(0, len(accession.altered_md5_matches))
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.altered_md5_matches))
+        self.assertEqual(1, len(restore.altered_md5_matches))
+
+    def test_multiple_altered_md_matches_to_one_accession(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore1 = create_perfect_match(accession)
+        restore1.md5 = 'altered_md5_1'
+        restore2 = create_perfect_match(accession)
+        restore2.md5 = 'altered_md5_2'
+
+        session.add(accession)
+        session.add(restore1)
+        session.add(restore2)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+
+        self.assertEqual(2, len(new_matches_found))
+        self.assertEqual(2, len(accession.altered_md5_matches))
+        self.assertEqual(1, len(restore1.altered_md5_matches))
+        self.assertEqual(accession, restore1.altered_md5_matches[0])
+        self.assertEqual(1, len(restore2.altered_md5_matches))
+        self.assertEqual(accession, restore2.altered_md5_matches[0])
+
+    def test_accession_with_perfect_match_and_altered_md5_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        perfect_restore = create_perfect_match(accession)
+        altered_restore = create_perfect_match(accession)
+        altered_restore.md5 = 'altered_md5'
+
+        session.add(accession)
+        session.add(perfect_restore)
+        session.add(altered_restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        perfect_matches_found = find_perfect_matches(session, accessions)
+        altered_md5_matches_found = find_altered_md5_matches(session, accessions)
+        self.assertEqual(1, len(perfect_matches_found))
+        self.assertEqual(1, len(altered_md5_matches_found))
+        self.assertEqual(perfect_restore, accession.perfect_matches[0])
+        self.assertEqual(altered_restore, accession.altered_md5_matches[0])
+
+    def test_altered_md5_match_does_not_include_perfect_match(self):
+        # In this test, we are running find_altered_md5_matches without first
+        # running find_perfect_matches, to ensure a perfect match is not added
+        # to the altered md5 matches
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        perfect_restore = create_perfect_match(accession)
+        altered_restore = create_perfect_match(accession)
+        altered_restore.md5 = 'altered_md5'
+
+        session.add(accession)
+        session.add(perfect_restore)
+        session.add(altered_restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        altered_md5_matches_found = find_altered_md5_matches(session, accessions)
+        self.assertEqual(0, len(accession.perfect_matches))
+
+        self.assertEqual(1, len(altered_md5_matches_found))
+        self.assertEqual(altered_restore, accession.altered_md5_matches[0])
+
+    def test_same_filename_but_different_md5_and_bytes(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'altered_md5'
+        restore.bytes = restore.bytes + 100
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        # Verify that filenames are the same, but MD5 and bytes differ
+        self.assertEqual(accession.filename, restore.filename)
+        self.assertNotEqual(accession.md5, restore.md5)
+        self.assertNotEqual(accession.bytes, restore.bytes)
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(0, len(accession.altered_md5_matches))
+        self.assertEqual(0, len(restore.altered_md5_matches))
+
+    def test_same_bytes_but_different_filename_and_md5(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'altered_md5'
+        restore.filename = 'altered_filename'
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        # Verify that bytes are the same, but MD5 and filenames differ
+        self.assertEqual(accession.bytes, restore.bytes)
+        self.assertNotEqual(accession.filename, restore.filename)
+        self.assertNotEqual(accession.md5, restore.md5)
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(0, len(accession.altered_md5_matches))
+        self.assertEqual(0, len(restore.altered_md5_matches))
+
+    def test_finding_altered_md5_matches_more_than_once(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'altered_md5'
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.altered_md5_matches))
+        self.assertEqual(1, len(restore.altered_md5_matches))
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(1, len(accession.altered_md5_matches))
+        self.assertEqual(1, len(restore.altered_md5_matches))

--- a/tests/test_filename_only_matches.py
+++ b/tests/test_filename_only_matches.py
@@ -1,0 +1,239 @@
+import patsy.database
+from sqlalchemy import create_engine
+from patsy.model import Base
+from patsy.perfect_matches import find_perfect_matches
+from patsy.altered_md5_matches import find_altered_md5_matches
+from patsy.filename_only_matches import find_filename_only_matches
+import unittest
+from patsy.model import Accession
+from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match
+
+Session = patsy.database.Session
+
+
+class TestFilenameOnlyMatches(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine('sqlite:///:memory:')
+        Session.configure(bind=engine)
+        Base.metadata.create_all(engine)
+
+    def test_no_filename_only_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = RestoreBuilder().build()
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        # Verify that MD5 checksums, filenames, and bytes are not equal
+        self.assertNotEqual(accession.md5, restore.md5)
+        self.assertNotEqual(accession.filename, restore.filename)
+        self.assertNotEqual(accession.bytes, restore.bytes)
+
+        accessions = session.query(Accession)
+        new_matches_found = find_filename_only_matches(session, accessions)
+
+        # No perfect match should be found
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(0, len(accession.filename_only_matches))
+        self.assertEqual(0, len(restore.filename_only_matches))
+
+    def test_one_filename_only_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'filename_only_md5'
+        restore.bytes = restore.bytes + 100
+
+        self.assertEqual(accession.filename, restore.filename)
+        self.assertNotEqual(accession.md5, restore.md5)
+        self.assertNotEqual(accession.bytes, restore.bytes)
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        self.assertEqual(0, len(accession.filename_only_matches))
+
+        accessions = session.query(Accession)
+        new_matches_found = find_filename_only_matches(session, accessions)
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.filename_only_matches))
+        self.assertEqual(1, len(restore.filename_only_matches))
+
+    def test_multiple_filename_only_matches_to_one_accession(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore1 = create_perfect_match(accession)
+        restore1.md5 = 'filename_only_md5_1'
+        restore1.bytes = restore1.bytes + 100
+        restore2 = create_perfect_match(accession)
+        restore2.md5 = 'filename_only_md5_2'
+        restore2.bytes = restore2.bytes + 100
+
+        session.add(accession)
+        session.add(restore1)
+        session.add(restore2)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_filename_only_matches(session, accessions)
+
+        self.assertEqual(2, len(new_matches_found))
+        self.assertEqual(2, len(accession.filename_only_matches))
+        self.assertEqual(1, len(restore1.filename_only_matches))
+        self.assertEqual(accession, restore1.filename_only_matches[0])
+        self.assertEqual(1, len(restore2.filename_only_matches))
+        self.assertEqual(accession, restore2.filename_only_matches[0])
+
+    def test_accession_with_perfect_match_and_altered_md5_match_and_filename_only_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        perfect_restore = create_perfect_match(accession)
+        altered_restore = create_perfect_match(accession)
+        altered_restore.md5 = 'altered_md5'
+        filename_only_restore = create_perfect_match(accession)
+        filename_only_restore.md5 = 'filename_only_md5'
+        filename_only_restore.bytes = filename_only_restore.bytes + 100
+
+        session.add(accession)
+        session.add(perfect_restore)
+        session.add(altered_restore)
+        session.add(filename_only_restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        perfect_matches_found = find_perfect_matches(session, accessions)
+        altered_md5_matches_found = find_altered_md5_matches(session, accessions)
+        filename_only_matches_found = find_filename_only_matches(session, accessions)
+        self.assertEqual(1, len(perfect_matches_found))
+        self.assertEqual(1, len(altered_md5_matches_found))
+        self.assertEqual(1, len(filename_only_matches_found))
+        self.assertEqual(perfect_restore, accession.perfect_matches[0])
+        self.assertEqual(altered_restore, accession.altered_md5_matches[0])
+        self.assertEqual(filename_only_restore, accession.filename_only_matches[0])
+
+    def test_filename_only_match_does_not_include_perfect_match(self):
+        # In this test, we are running find_filename_only_matches without first
+        # running find_perfect_matches, to ensure a perfect match is not added
+        # to the filename only matches
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        perfect_restore = create_perfect_match(accession)
+        filename_only_restore = create_perfect_match(accession)
+        filename_only_restore.md5 = 'filename_only_md5'
+        filename_only_restore.bytes = filename_only_restore.bytes + 100
+
+        session.add(accession)
+        session.add(perfect_restore)
+        session.add(filename_only_restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        filename_only_matches_found = find_filename_only_matches(session, accessions)
+        self.assertEqual(0, len(accession.perfect_matches))
+
+        self.assertEqual(1, len(filename_only_matches_found))
+        self.assertEqual(filename_only_restore, accession.filename_only_matches[0])
+
+    def test_filename_only_match_does_not_include_altered_md_match(self):
+        # In this test, we are running find_filename_only_matches without first
+        # running find_altered_md5_matches, to ensure an altered MD match
+        # is not added to the filename only matches
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        altered_restore = create_perfect_match(accession)
+        altered_restore.md5 = 'altered_md5'
+        filename_only_restore = create_perfect_match(accession)
+        filename_only_restore.md5 = 'filename_only_md5'
+        filename_only_restore.bytes = filename_only_restore.bytes + 100
+
+        session.add(accession)
+        session.add(altered_restore)
+        session.add(filename_only_restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        filename_only_matches_found = find_filename_only_matches(session, accessions)
+        self.assertEqual(0, len(accession.altered_md5_matches))
+
+        self.assertEqual(1, len(filename_only_matches_found))
+        self.assertEqual(filename_only_restore, accession.filename_only_matches[0])
+
+    def test_same_bytes_and_filename_but_different_md5(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'filename_only_md5'
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        # Verify that filename and bytes are the same, but MD5 differs
+        self.assertEqual(accession.bytes, restore.bytes)
+        self.assertEqual(accession.filename, restore.filename)
+        self.assertNotEqual(accession.md5, restore.md5)
+
+        accessions = session.query(Accession)
+        new_matches_found = find_filename_only_matches(session, accessions)
+
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(0, len(accession.filename_only_matches))
+        self.assertEqual(0, len(restore.filename_only_matches))
+
+    def test_same_bytes_but_different_filename_and_md5(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'filename_only_md5'
+        restore.filename = 'filename_only_filename'
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        # Verify that bytes are the same, but MD5 and filenames differ
+        self.assertEqual(accession.bytes, restore.bytes)
+        self.assertNotEqual(accession.filename, restore.filename)
+        self.assertNotEqual(accession.md5, restore.md5)
+
+        accessions = session.query(Accession)
+        new_matches_found = find_filename_only_matches(session, accessions)
+
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(0, len(accession.filename_only_matches))
+        self.assertEqual(0, len(restore.filename_only_matches))
+
+    def test_finding_filename_only_matches_more_than_once(self):
+        session = Session()
+
+        accession = AccessionBuilder().build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'filename_only_md5'
+        restore.bytes = restore.bytes + 100
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_filename_only_matches(session, accessions)
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.filename_only_matches))
+        self.assertEqual(1, len(restore.filename_only_matches))
+
+        accessions = session.query(Accession)
+        new_matches_found = find_filename_only_matches(session, accessions)
+        self.assertEqual(0, len(new_matches_found))
+        self.assertEqual(1, len(accession.filename_only_matches))
+        self.assertEqual(1, len(restore.filename_only_matches))

--- a/tests/test_perfect_matches.py
+++ b/tests/test_perfect_matches.py
@@ -4,7 +4,7 @@ from patsy.model import Base
 from patsy.perfect_matches import find_perfect_matches, get_accessions
 import unittest
 from patsy.model import Accession
-from .test_utils import AccessionBuilder, RestoreBuilder, create_perfect_match
+from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match
 
 Session = patsy.database.Session
 
@@ -171,26 +171,3 @@ class TestPerfectMatches(unittest.TestCase):
         self.assertEqual(0, len(new_matches_found))
         self.assertEqual(1, len(accession.perfect_matches))
         self.assertEqual(1, len(restore.perfect_matches))
-
-    def test_get_accessions(self):
-        session = Session()
-
-        accession_batch1 = AccessionBuilder().set_batch('Batch1').build()
-        accession_batch2 = AccessionBuilder().set_batch('Batch2').build()
-
-        session.add(accession_batch1)
-        session.add(accession_batch2)
-        session.commit()
-
-        # Calling with only sessions queries all accessions
-        accessions = get_accessions(session)
-        self.assertEqual(2, accessions.count())
-
-        # Calling with a batch only gives accessions in that batch
-        accessions = get_accessions(session, 'Batch1')
-        self.assertEqual(1, accessions.count())
-        self.assertEqual(accession_batch1, accessions[0])
-
-        accessions = get_accessions(session, 'Batch2')
-        self.assertEqual(1, accessions.count())
-        self.assertEqual(accession_batch2, accessions[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,151 +1,32 @@
-from patsy.model import Accession
-from patsy.model import Restore
-from faker import Faker
-import random
-import os
+import patsy.database
+import unittest
+from patsy.utils import get_accessions
+from .utils import AccessionBuilder
 
 
-class AccessionBuilder:
-    """
-    Builder for an Accession object, initially populated with random values.
-
-    Specific values can be set using the setter methods, i.e.,
-
-    AccessionBuilder().set_filename('foo.txt').build()
-    """
-    def __init__(self):
-        fake = Faker()
-        file_path = fake.file_path()
-
-        self.batch = 'Batch' + str(random.randint(0, 100))
-        self.bytes = random.randint(0, 10000000)
-        self.relpath = file_path[1:]
-        self.md5 = fake.md5()
-        self.filename = os.path.basename(file_path)
-        self.sourcefile = fake.file_path()
-        self.sourceline = random.randint(0, 10000)
-        self.timestamp = str(fake.date_time())
-
-    def set_md5(self, md5):
-        """
-        Sets the MD5 checksum
-        :param md5: the MD5 checksum to set
-        :return: self
-        """
-        self.md5 = md5
-        return self
-
-    def set_filename(self, filename):
-        """
-        Sets the base filename
-        :param filename: the base filename to set
-        :return: self
-        """
-        self.filename = filename
-        self.relpath = os.path.dirname(self.relpath) + "/" + filename
-        return self
-
-    def set_bytes(self, bytes):
-        """
-        Sets the number of bytes
-        :param bytes: the number of bytes
-        :return: self
-        """
-        self.bytes = bytes
-        return self
-
-    def set_batch(self, batch):
-        """
-        Sets the name of the batch the accession belongs to
-        :param bytes: the name of the batch
-        :return: self
-        """
-        self.batch = batch
-        return self
-
-    def build(self):
-        """
-        Returns an Accession object
-        :return: as Accession object
-        """
-        return Accession(batch=self.batch, bytes=self.bytes, filename=self.filename,
-                         md5=self.md5, relpath=self.relpath, sourcefile=self.sourcefile,
-                         sourceline=self.sourceline, timestamp=self.timestamp)
+Session = patsy.database.Session
 
 
-class RestoreBuilder:
-    """
-    Builder for a Restore object, initially populated with random values.
+class TestUtils(unittest.TestCase):
+    def test_get_accessions(self):
+        session = Session()
 
-    Specific values can be set using the setter methods, i.e.,
+        accession_batch1 = AccessionBuilder().set_batch('Batch1').build()
+        accession_batch2 = AccessionBuilder().set_batch('Batch2').build()
 
-    RestoreBuilder().set_filename('foo.txt').build()
-    """
-    def __init__(self):
-        fake = Faker()
+        session.add(accession_batch1)
+        session.add(accession_batch2)
+        session.commit()
 
-        self.md5 = fake.md5()
-        self.filepath = fake.file_path()
-        self.filename = os.path.basename(self.filepath)
-        self.bytes = random.randint(0, 10000000)
+        # Calling with only sessions queries all accessions
+        accessions = get_accessions(session)
+        self.assertEqual(2, accessions.count())
 
-    def set_md5(self, md5):
-        """
-        Sets the MD5 checksum
-        :param md5: the MD5 checksum to set
-        :return: self
-        """
-        self.md5 = md5
-        return self
+        # Calling with a batch only gives accessions in that batch
+        accessions = get_accessions(session, 'Batch1')
+        self.assertEqual(1, accessions.count())
+        self.assertEqual(accession_batch1, accessions[0])
 
-    def set_filename(self, filename):
-        """
-        Sets the base filename
-        :param filename: the base filename to set
-        :return: self
-        """
-        self.filename = filename
-        self.filepath = self.filepath + "/" + filename
-        return self
-
-    def set_filepath(self, filepath):
-        """
-        Sets the filepath
-        :param filepath: the filepath to set
-        :return: self
-        """
-        self.filepath = filepath
-        return self
-
-    def set_bytes(self, bytes):
-        """
-        Sets the number of bytes
-        :param bytes: the number of bytes
-        :return: self
-        """
-        self.bytes = bytes
-        return self
-
-    def build(self):
-        """
-        Returns a Restore object
-        :return: a Restore object
-        """
-        return Restore(md5=self.md5, filepath=self.filepath, filename=self.filename, bytes=self.bytes)
-
-
-def create_perfect_match(accession):
-    """
-    Returns a Restore object that is a "perfect" match for the given Accession,
-    i.e., has matching "md5", "filename", and "bytes" fields
-
-    :param accession: the Accession to create a perfect match for
-    :return: a Restore object that is a "perfect" match for the given Accession
-    """
-    restore_builder = RestoreBuilder()
-    restore_builder.set_md5(accession.md5)
-    restore_builder.set_bytes(accession.bytes)
-    restore_builder.set_filename(accession.filename)
-    restore = restore_builder.build()
-
-    return restore
+        accessions = get_accessions(session, 'Batch2')
+        self.assertEqual(1, accessions.count())
+        self.assertEqual(accession_batch2, accessions[0])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,151 @@
+from patsy.model import Accession
+from patsy.model import Restore
+from faker import Faker
+import random
+import os
+
+
+class AccessionBuilder:
+    """
+    Builder for an Accession object, initially populated with random values.
+
+    Specific values can be set using the setter methods, i.e.,
+
+    AccessionBuilder().set_filename('foo.txt').build()
+    """
+    def __init__(self):
+        fake = Faker()
+        file_path = fake.file_path()
+
+        self.batch = 'Batch' + str(random.randint(0, 100))
+        self.bytes = random.randint(0, 10000000)
+        self.relpath = file_path[1:]
+        self.md5 = fake.md5()
+        self.filename = os.path.basename(file_path)
+        self.sourcefile = fake.file_path()
+        self.sourceline = random.randint(0, 10000)
+        self.timestamp = str(fake.date_time())
+
+    def set_md5(self, md5):
+        """
+        Sets the MD5 checksum
+        :param md5: the MD5 checksum to set
+        :return: self
+        """
+        self.md5 = md5
+        return self
+
+    def set_filename(self, filename):
+        """
+        Sets the base filename
+        :param filename: the base filename to set
+        :return: self
+        """
+        self.filename = filename
+        self.relpath = os.path.dirname(self.relpath) + "/" + filename
+        return self
+
+    def set_bytes(self, bytes):
+        """
+        Sets the number of bytes
+        :param bytes: the number of bytes
+        :return: self
+        """
+        self.bytes = bytes
+        return self
+
+    def set_batch(self, batch):
+        """
+        Sets the name of the batch the accession belongs to
+        :param bytes: the name of the batch
+        :return: self
+        """
+        self.batch = batch
+        return self
+
+    def build(self):
+        """
+        Returns an Accession object
+        :return: as Accession object
+        """
+        return Accession(batch=self.batch, bytes=self.bytes, filename=self.filename,
+                         md5=self.md5, relpath=self.relpath, sourcefile=self.sourcefile,
+                         sourceline=self.sourceline, timestamp=self.timestamp)
+
+
+class RestoreBuilder:
+    """
+    Builder for a Restore object, initially populated with random values.
+
+    Specific values can be set using the setter methods, i.e.,
+
+    RestoreBuilder().set_filename('foo.txt').build()
+    """
+    def __init__(self):
+        fake = Faker()
+
+        self.md5 = fake.md5()
+        self.filepath = fake.file_path()
+        self.filename = os.path.basename(self.filepath)
+        self.bytes = random.randint(0, 10000000)
+
+    def set_md5(self, md5):
+        """
+        Sets the MD5 checksum
+        :param md5: the MD5 checksum to set
+        :return: self
+        """
+        self.md5 = md5
+        return self
+
+    def set_filename(self, filename):
+        """
+        Sets the base filename
+        :param filename: the base filename to set
+        :return: self
+        """
+        self.filename = filename
+        self.filepath = self.filepath + "/" + filename
+        return self
+
+    def set_filepath(self, filepath):
+        """
+        Sets the filepath
+        :param filepath: the filepath to set
+        :return: self
+        """
+        self.filepath = filepath
+        return self
+
+    def set_bytes(self, bytes):
+        """
+        Sets the number of bytes
+        :param bytes: the number of bytes
+        :return: self
+        """
+        self.bytes = bytes
+        return self
+
+    def build(self):
+        """
+        Returns a Restore object
+        :return: a Restore object
+        """
+        return Restore(md5=self.md5, filepath=self.filepath, filename=self.filename, bytes=self.bytes)
+
+
+def create_perfect_match(accession):
+    """
+    Returns a Restore object that is a "perfect" match for the given Accession,
+    i.e., has matching "md5", "filename", and "bytes" fields
+
+    :param accession: the Accession to create a perfect match for
+    :return: a Restore object that is a "perfect" match for the given Accession
+    """
+    restore_builder = RestoreBuilder()
+    restore_builder.set_md5(accession.md5)
+    restore_builder.set_bytes(accession.bytes)
+    restore_builder.set_filename(accession.filename)
+    restore = restore_builder.build()
+
+    return restore


### PR DESCRIPTION
In "model.py" created a "filename_only_matches" table, which serves as
an association table for doing a many-to-many match between accessions
and restores.

Added "patsy/ilename_only_matches.py" to hold the code that performs the
filename only match query.

Added "find_filename_only_matches" command to the CLI.

Added sample data for testing.

Updated README.md.

https://issues.umd.edu/browse/LIBITD-1533