### PR TITLE
LIBITD-1575. Added index for patsy-db "restore.filename" column

### DIFF
--- a/patsy/model.py
+++ b/patsy/model.py
@@ -85,6 +85,7 @@ class Restore(Base):
 
 Index('restore_filepath', Restore.filepath, unique=True)
 Index('restore_md5', Restore.md5, unique=False)
+Index('restore_filename', Restore.filename, unique=False)
 
 
 class Transfer(Base):


### PR DESCRIPTION
Having an index on the "restore.filename" column significantly speeds
up the "find_altered_md5_matches" command.

https://issues.umd.edu/browse/LIBITD-1575