### PR TITLE
LIBITD-1587. Added "delete_accessions" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,41 @@ unmatched accession records:
 > python3 -m patsy --database <SQLITE_DATABASE_FILE> unmatched_accessions --batch <BATCH> --delete
 ```
 
+### Deleting all accessions in a batch
+
+----
+#### SQLite and Foreign Key Constraints
+
+By default, SQLite does not enable foreign key constraints. When deleting
+accessions, the "sqlite3" CLI client will *not* delete related matches in the
+"perfect_matches", "altered_md5_matches", or "filename_only_matches" tables,
+unless foreign key constraints are enabled, using the following command
+(which must be entered in every session, as it is not persisted):
+
+```
+PRAGMA foreign_keys=ON;
+```
+
+The "DB Browser for SQLite" GUI client (https://sqlitebrowser.org/) has
+foreign key constraints enabled by default, and so should be safe to use.
+
+When using either of these clients to delete entries using SQL, be sure that
+foreign key constraints are enabled, and also verify that the expected records
+in related tables are deleted.
+----
+
+An entire batch of accessions can be deleted using the following command, which
+will properly remove related entries in the "perfect_matches",
+"altered_md5_matches", and "filename_only_matches" tables:
+
+```
+> python3 -m patsy --database <SQLITE_DATABASE_FILE> delete_accessions --batch <BATCH>
+```
+
+where <SQLITE_DATABASE_FILE> is the path to the SQLite database, and \<BATCH> is
+a batch name (corresponding to the "batch" field in the accession). The \<BATCH>
+parameter is required.
+
 ## Accession Records
 
 Accession records represent the "canonical" information about an asset. These

--- a/patsy/__main__.py
+++ b/patsy/__main__.py
@@ -12,6 +12,7 @@ from .altered_md5_matches import find_altered_md5_matches_command
 from .filename_only_matches import find_filename_only_matches_command
 from .transfer_matches import find_transfer_matches_command
 from .unmatched_accessions import unmatched_accessions_command
+from .delete_accessions import delete_accessions_command
 from .database import use_database_file
 from .restore import RestoreCsvLoader
 from .transfer import TransferCsvLoader
@@ -186,6 +187,18 @@ def get_args():
         help='The (optional) file to write the unmatched accessions to in CSV format. Defaults to standard out.'
         )
 
+    # create the parser for the "unmatched_accessions" command
+    delete_accessions_subcommand = subparsers.add_parser(
+        'delete_accessions',
+        help='Delets ALL the accessions in the given batch'
+        )
+    delete_accessions_subcommand.add_argument(
+        '-b', '--batch',
+        action='store',
+        required=True,
+        help='Batch of accessions to delete.'
+        )
+
     return parser.parse_args()
 
 
@@ -267,6 +280,12 @@ def main():
         use_database_file(args.database)
         result = unmatched_accessions_command(args.batch, args.output, args.delete)
         print("----- Unmatched Accessions ----")
+        print(result)
+
+    elif args.cmd == "delete_accessions":
+        use_database_file(args.database)
+        result = delete_accessions_command(args.batch)
+        print("----- Delete Accessions ----")
         print(result)
 
     print(f"Actions complete!")

--- a/patsy/database.py
+++ b/patsy/database.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 from .model import Base
@@ -14,7 +14,14 @@ def use_database_file(database):
         print(f"Using database at {database}...")         
     db_path = f"sqlite:///{database}"
     print("Binding the database session...")
+
     engine = create_engine(db_path)
+
+    # Enable foreign key constraints
+    def _fk_pragma_on_connect(dbapi_con, con_record):
+        dbapi_con.execute('pragma foreign_keys=ON')
+
+    event.listen(engine, 'connect', _fk_pragma_on_connect)
     Session.configure(bind=engine)
 
 

--- a/patsy/delete_accessions.py
+++ b/patsy/delete_accessions.py
@@ -1,0 +1,39 @@
+from .database import Session
+from .model import Accession
+
+
+def delete_accessions_command(batch=None):
+    """
+    Called by the CLI to perform the "delete_accessions" command.
+
+    :param batch: The name of the batch to delete
+    :return: a String containing information about the deleted accessions
+    """
+    session = Session()
+
+    num_deleted = delete_accessions(session, batch)
+
+    session.commit()
+    session.close()
+
+    return f"Deleted {num_deleted} accessions from batch '{batch}'."
+
+
+def delete_accessions(session, batch=None):
+    """
+    Deletes all accessions in the given batch.
+
+    Due to the way the database is constructed, this will also delete all the
+    related entries in the "perfect_matches", "altered_md5_matches", and
+    "filename_only_matches" tables.
+
+    :param session: the Session in which to perform the query
+    :param batch: The name of the batch delete. A batch name
+                  must be provided.
+    :return: a (possibly empty) array of unmatched accessions.
+    """
+    if batch is None:
+        raise ValueError("Batch is required.")
+
+    num_deleted = session.query(Accession).filter(Accession.batch == batch).delete(synchronize_session=False)
+    return num_deleted

--- a/patsy/model.py
+++ b/patsy/model.py
@@ -8,7 +8,7 @@ Base = declarative_base()
 
 # Many-to-many relationship between accessions and restores that are perfect matches
 perfect_matches_table = Table('perfect_matches', Base.metadata,
-                              Column('accession_id', Integer, ForeignKey('accessions.id')),
+                              Column('accession_id', Integer, ForeignKey('accessions.id', ondelete='CASCADE')),
                               Column('restore_id', Integer, ForeignKey('restores.id'))
                               )
 
@@ -19,14 +19,14 @@ Index('perfect_matches_restore_id', perfect_matches_table.c.restore_id, unique=F
 # Many-to-many relationship between accessions and restores where filename and bytes
 # are the same, but the MD5 checksum is different
 altered_md5_matches_table = Table('altered_md5_matches', Base.metadata,
-                                  Column('accession_id', Integer, ForeignKey('accessions.id')),
+                                  Column('accession_id', Integer, ForeignKey('accessions.id', ondelete='CASCADE')),
                                   Column('restore_id', Integer, ForeignKey('restores.id'))
                                   )
 
 # Many-to-many relationship between accessions and restores where the filename
 # is the same, but the MD5 checksum and bytes are different
 filename_only_matches_table = Table('filename_only_matches', Base.metadata,
-                                    Column('accession_id', Integer, ForeignKey('accessions.id')),
+                                    Column('accession_id', Integer, ForeignKey('accessions.id', ondelete='CASCADE')),
                                     Column('restore_id', Integer, ForeignKey('restores.id'))
                                     )
 

--- a/tests/test_accession.py
+++ b/tests/test_accession.py
@@ -1,17 +1,17 @@
 import patsy.database
 from patsy.accession import AccessionCsvLoader
-from sqlalchemy import create_engine
 from patsy.model import Base
 import unittest
 from patsy.model import Accession
+from .utils import create_test_engine
 
 Session = patsy.database.Session
 
 
 class TestAccession(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_load_single_file(self):

--- a/tests/test_altered_md5s.py
+++ b/tests/test_altered_md5s.py
@@ -3,7 +3,7 @@ from patsy.model import Base
 from patsy.perfect_matches import find_perfect_matches
 from patsy.altered_md5_matches import find_altered_md5_matches
 import unittest
-from patsy.model import Accession
+from patsy.model import Accession, Restore, altered_md5_matches_table
 from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match, create_test_engine
 
 Session = patsy.database.Session
@@ -194,3 +194,108 @@ class TestAlteredMd5sMatches(unittest.TestCase):
         self.assertEqual(0, len(new_matches_found))
         self.assertEqual(1, len(accession.altered_md5_matches))
         self.assertEqual(1, len(restore.altered_md5_matches))
+
+    def test_deleting_accession_using_orm_should_delete_altered_md5_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().set_batch("batch_to_delete").build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'altered_md5'
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+        session.commit()
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.altered_md5_matches))
+        self.assertEqual(1, len(restore.altered_md5_matches))
+
+        # Delete using SQLAlchemy ORM
+        session.delete(accession)
+        session.commit()
+
+        accessions_count = session.query(Accession).count()
+        restores_count = session.query(Restore).count()
+        matches_count = session.query(altered_md5_matches_table).count()
+        self.assertEqual(0, accessions_count)
+        self.assertEqual(1, restores_count)  # Restores are not affected
+        self.assertEqual(0, matches_count)
+        self.assertEqual([], restore.altered_md5_matches)
+
+    def test_deleting_accession_using_raw_sql_should_delete_altered_md5_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().set_batch("batch_to_delete").build()
+        restore = create_perfect_match(accession)
+        restore.md5 = 'altered_md5'
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+        session.commit()
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.altered_md5_matches))
+        self.assertEqual(1, len(restore.altered_md5_matches))
+
+        # Delete using raw SQL, not SQLAlchemy, to test ON DELETE CASCADE
+        session.execute("DELETE FROM accessions where accessions.batch = 'batch_to_delete'")
+        session.commit()
+
+        accessions_count = session.query(Accession).count()
+        restores_count = session.query(Restore).count()
+        matches_count = session.query(altered_md5_matches_table).count()
+        self.assertEqual(0, accessions_count)
+        self.assertEqual(1, restores_count)  # Restores are not affected
+        self.assertEqual(0, matches_count)
+        self.assertEqual([], restore.altered_md5_matches)
+
+    def test_deleting_accession_using_raw_sql_should_delete_altered_md5_match_not_affect_other_matches(self):
+        session = Session()
+
+        accession1 = AccessionBuilder().set_batch("batch_to_delete").build()
+        restore1 = create_perfect_match(accession1)
+        restore1.md5 = 'altered_md5'
+
+        accession2 = AccessionBuilder().set_batch("batch_to_preserve").build()
+        restore2 = create_perfect_match(accession2)
+        restore2.md5 = 'altered_md5'
+
+        session.add(accession1)
+        session.add(restore1)
+
+        session.add(accession2)
+        session.add(restore2)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_altered_md5_matches(session, accessions)
+        session.commit()
+
+        self.assertEqual(2, len(new_matches_found))
+        self.assertEqual(1, len(accession1.altered_md5_matches))
+        self.assertEqual(1, len(restore1.altered_md5_matches))
+        self.assertEqual(1, len(accession2.altered_md5_matches))
+        self.assertEqual(1, len(restore2.altered_md5_matches))
+
+        # Delete using raw SQL, not SQLAlchemy, to test ON DELETE CASCADE
+        connection = session.connection()
+        connection.execute("DELETE FROM accessions where accessions.batch = 'batch_to_delete'")
+        session.commit()
+
+        accessions_count = session.query(Accession).count()
+        restores_count = session.query(Restore).count()
+        matches_count = session.query(altered_md5_matches_table).count()
+        self.assertEqual(1, accessions_count)
+        self.assertEqual(2, restores_count)  # Restores are no affected
+        self.assertEqual(1, matches_count)
+        self.assertEqual([], restore1.altered_md5_matches)
+        self.assertIn(accession2, restore2.altered_md5_matches)
+        self.assertIn(restore2, accession2.altered_md5_matches)

--- a/tests/test_altered_md5s.py
+++ b/tests/test_altered_md5s.py
@@ -1,19 +1,18 @@
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base
 from patsy.perfect_matches import find_perfect_matches
 from patsy.altered_md5_matches import find_altered_md5_matches
 import unittest
 from patsy.model import Accession
-from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match
+from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match, create_test_engine
 
 Session = patsy.database.Session
 
 
 class TestAlteredMd5sMatches(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_no_altered_md5_match(self):

--- a/tests/test_aws_manifest.py
+++ b/tests/test_aws_manifest.py
@@ -1,13 +1,10 @@
 import io
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base
 from patsy.perfect_matches import find_perfect_matches
 from patsy.transfer_matches import find_transfer_matches
-from patsy.altered_md5_matches import find_altered_md5_matches
 import unittest
-from patsy.model import Accession
-from .utils import AccessionBuilder, RestoreBuilder, TransferBuilder, create_perfect_match
+from .utils import AccessionBuilder, TransferBuilder, create_perfect_match, create_test_engine
 from patsy.aws_manifest import find_untransferred_accessions, generate_manifest_entries, output_manifest_entries
 
 Session = patsy.database.Session
@@ -15,8 +12,8 @@ Session = patsy.database.Session
 
 class TestAwsManifest(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
         session = Session()

--- a/tests/test_batch_stats.py
+++ b/tests/test_batch_stats.py
@@ -1,10 +1,9 @@
 import io
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base, Transfer
 from patsy.batch_stats import get_stats_for_batch, output_batch_stats_entries, batch_stats
 import unittest
-from .utils import AccessionBuilder, TransferBuilder, create_perfect_match
+from .utils import AccessionBuilder, TransferBuilder, create_perfect_match, create_test_engine
 from patsy.perfect_matches import find_perfect_matches
 from patsy.transfer_matches import find_transfer_matches
 from patsy.utils import get_accessions, get_batch_names
@@ -14,8 +13,8 @@ Session = patsy.database.Session
 
 class TestBatchStats(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_get_stats_for_batch_no_data(self):

--- a/tests/test_delete_accessions.py
+++ b/tests/test_delete_accessions.py
@@ -1,0 +1,78 @@
+import patsy.database
+from patsy.delete_accessions import delete_accessions
+from patsy.model import Base
+import unittest
+from patsy.model import Accession
+from .utils import create_test_engine, AccessionBuilder, create_perfect_match
+from patsy.perfect_matches import find_perfect_matches
+
+Session = patsy.database.Session
+
+
+class TestDeleteAccession(unittest.TestCase):
+    def setUp(self):
+        create_test_engine()
+        engine = Session().get_bind()
+        Base.metadata.create_all(engine)
+
+    def test_batch_with_one_accession(self):
+        session = Session()
+
+        accession = AccessionBuilder().set_batch("batch_to_delete").build()
+        session.add(accession)
+        session.commit()
+
+        accessions = session.query(Accession)
+        self.assertEqual(1, accessions.count())
+
+        delete_accessions(session, "batch_to_delete")
+        session.commit()
+
+        accessions = session.query(Accession)
+        self.assertEqual(0, accessions.count())
+
+    def test_batch_with_two_accessions_in_different_batches(self):
+        session = Session()
+
+        accession1 = AccessionBuilder().set_batch("batch_to_delete").build()
+        accession2 = AccessionBuilder().set_batch("batch_to_preserve").build()
+
+        session.add(accession1)
+        session.add(accession2)
+        session.commit()
+
+        accessions = session.query(Accession)
+        self.assertEqual(2, accessions.count())
+
+        delete_accessions(session, "batch_to_delete")
+        session.commit()
+
+        accessions = session.query(Accession)
+        self.assertEqual(1, accessions.count())
+        self.assertEqual(accession2, accessions.first())
+
+    def test_batch_with_accession_with_perfect_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().set_batch("batch_to_delete").build()
+        restore = create_perfect_match(accession)
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_perfect_matches(session, accessions)
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.perfect_matches))
+        self.assertEqual(1, len(restore.perfect_matches))
+        self.assertEqual(accession, restore.perfect_matches[0])
+        self.assertEqual(restore, accession.perfect_matches[0])
+
+        delete_accessions(session, "batch_to_delete")
+        session.commit()
+
+        accessions = session.query(Accession)
+        self.assertEqual(0, accessions.count())
+        self.assertEqual([], restore.perfect_matches)

--- a/tests/test_filename_only_matches.py
+++ b/tests/test_filename_only_matches.py
@@ -1,20 +1,19 @@
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base
 from patsy.perfect_matches import find_perfect_matches
 from patsy.altered_md5_matches import find_altered_md5_matches
 from patsy.filename_only_matches import find_filename_only_matches
 import unittest
 from patsy.model import Accession
-from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match
+from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match, create_test_engine
 
 Session = patsy.database.Session
 
 
 class TestFilenameOnlyMatches(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_no_filename_only_match(self):

--- a/tests/test_perfect_matches.py
+++ b/tests/test_perfect_matches.py
@@ -170,3 +170,104 @@ class TestPerfectMatches(unittest.TestCase):
         self.assertEqual(0, len(new_matches_found))
         self.assertEqual(1, len(accession.perfect_matches))
         self.assertEqual(1, len(restore.perfect_matches))
+
+    def test_deleting_accession_using_orm_should_delete_perfect_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().set_batch("batch_to_delete").build()
+        restore = create_perfect_match(accession)
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_perfect_matches(session, accessions)
+        session.commit()
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.perfect_matches))
+        self.assertEqual(1, len(restore.perfect_matches))
+
+        # Delete using SQLAlchemy ORM
+        session.delete(accession)
+        session.commit()
+
+        accessions_count = session.query(Accession).count()
+        restores_count = session.query(Restore).count()
+        matches_count = session.query(perfect_matches_table).count()
+        self.assertEqual(0, accessions_count)
+        self.assertEqual(1, restores_count)  # Restores are not affected
+        self.assertEqual(0, matches_count)
+        self.assertEqual([], restore.perfect_matches)
+
+    def test_deleting_accession_using_raw_sql_should_delete_perfect_match(self):
+        session = Session()
+
+        accession = AccessionBuilder().set_batch("batch_to_delete").build()
+        restore = create_perfect_match(accession)
+
+        session.add(accession)
+        session.add(restore)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_perfect_matches(session, accessions)
+        session.commit()
+
+        self.assertEqual(1, len(new_matches_found))
+        self.assertEqual(1, len(accession.perfect_matches))
+        self.assertEqual(1, len(restore.perfect_matches))
+
+        # Delete using raw SQL, not SQLAlchemy, to test ON DELETE CASCADE
+        session.execute("DELETE FROM accessions where accessions.batch = 'batch_to_delete'")
+        session.commit()
+
+        accessions_count = session.query(Accession).count()
+        restores_count = session.query(Restore).count()
+        matches_count = session.query(perfect_matches_table).count()
+        self.assertEqual(0, accessions_count)
+        self.assertEqual(1, restores_count)  # Restores are not affected
+        self.assertEqual(0, matches_count)
+        self.assertEqual([], restore.perfect_matches)
+
+    def test_deleting_accession_using_raw_sql_should_delete_perfect_match_not_affect_other_matches(self):
+        session = Session()
+
+        accession1 = AccessionBuilder().set_batch("batch_to_delete").build()
+        restore1 = create_perfect_match(accession1)
+
+        accession2 = AccessionBuilder().set_batch("batch_to_preserve").build()
+        restore2 = create_perfect_match(accession2)
+
+        session.add(accession1)
+        session.add(restore1)
+
+        session.add(accession2)
+        session.add(restore2)
+        session.commit()
+
+        accessions = session.query(Accession)
+        new_matches_found = find_perfect_matches(session, accessions)
+        session.commit()
+
+        self.assertEqual(2, len(new_matches_found))
+        self.assertEqual(1, len(accession1.perfect_matches))
+        self.assertEqual(1, len(restore1.perfect_matches))
+        self.assertEqual(1, len(accession2.perfect_matches))
+        self.assertEqual(1, len(restore2.perfect_matches))
+
+        # Delete using raw SQL, not SQLAlchemy, to test ON DELETE CASCADE
+        connection = session.connection()
+        connection.execute("DELETE FROM accessions where accessions.batch = 'batch_to_delete'")
+        session.commit()
+
+        accessions_count = session.query(Accession).count()
+        restores_count = session.query(Restore).count()
+        matches_count = session.query(perfect_matches_table).count()
+        self.assertEqual(1, accessions_count)
+        self.assertEqual(2, restores_count)  # Restores are no affected
+        self.assertEqual(1, matches_count)
+        self.assertEqual([], restore1.perfect_matches)
+        self.assertIn(accession2, restore2.perfect_matches)
+        self.assertIn(restore2, accession2.perfect_matches)

--- a/tests/test_perfect_matches.py
+++ b/tests/test_perfect_matches.py
@@ -1,18 +1,17 @@
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base
 from patsy.perfect_matches import find_perfect_matches
 import unittest
-from patsy.model import Accession
-from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match
+from patsy.model import Accession, Restore, perfect_matches_table
+from .utils import AccessionBuilder, RestoreBuilder, create_perfect_match, create_test_engine
 
 Session = patsy.database.Session
 
 
 class TestPerfectMatches(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_no_perfect_match(self):

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,17 +1,17 @@
 import patsy.database
 from patsy.restore import RestoreCsvLoader
-from sqlalchemy import create_engine
 from patsy.model import Base
 import unittest
 from patsy.model import Restore
+from .utils import create_test_engine
 
 Session = patsy.database.Session
 
 
 class TestRestore(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_load_single_file(self):

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,17 +1,17 @@
 import patsy.database
 from patsy.transfer import TransferCsvLoader
-from sqlalchemy import create_engine
 from patsy.model import Base
 import unittest
 from patsy.model import Transfer
+from .utils import create_test_engine
 
 Session = patsy.database.Session
 
 
 class TestTransfer(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_load_single_file(self):

--- a/tests/test_transfer_matches.py
+++ b/tests/test_transfer_matches.py
@@ -1,18 +1,17 @@
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base
 from patsy.transfer_matches import find_transfer_matches
 import unittest
 from patsy.model import Transfer
-from .utils import RestoreBuilder, TransferBuilder
+from .utils import RestoreBuilder, TransferBuilder, create_test_engine
 
 Session = patsy.database.Session
 
 
 class TestTransferMatches(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_no_transfer_match(self):

--- a/tests/test_unmatched_accessions.py
+++ b/tests/test_unmatched_accessions.py
@@ -1,10 +1,9 @@
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base, Accession, perfect_matches_table, filename_only_matches_table, altered_md5_matches_table
 from patsy.unmatched_accessions import unmatched_accessions, unmatched_accessions_output, delete_accessions
 from patsy.perfect_matches import find_perfect_matches
 import unittest
-from .utils import AccessionBuilder, create_perfect_match
+from .utils import AccessionBuilder, create_perfect_match, create_test_engine
 import io
 
 Session = patsy.database.Session
@@ -12,8 +11,8 @@ Session = patsy.database.Session
 
 class TestTransferMatches(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_unmatched_accessions_throws_error_if_batch_not_provided(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,8 @@
 import patsy.database
-from sqlalchemy import create_engine
 from patsy.model import Base, Transfer
 import unittest
 from patsy.utils import get_accessions, get_unmatched_transfers, get_batch_names
-from .utils import AccessionBuilder, RestoreBuilder, TransferBuilder
+from .utils import AccessionBuilder, RestoreBuilder, TransferBuilder, create_test_engine
 
 
 Session = patsy.database.Session
@@ -11,8 +10,8 @@ Session = patsy.database.Session
 
 class TestUtils(unittest.TestCase):
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:')
-        Session.configure(bind=engine)
+        create_test_engine()
+        engine = Session().get_bind()
         Base.metadata.create_all(engine)
 
     def test_get_accessions(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ from patsy.model import Accession, Restore, Transfer
 from faker import Faker
 import random
 import os
+from patsy.database import use_database_file
 
 
 class AccessionBuilder:
@@ -197,3 +198,13 @@ def create_perfect_match(accession):
     restore = restore_builder.build()
 
     return restore
+
+
+def create_test_engine():
+    """
+    Returns an SQLAlchemy Engine, configured for testing.
+
+    :return: an SQLAlchemy Engine, configured for testing.
+    """
+    engine = use_database_file(":memory:")
+    return engine


### PR DESCRIPTION
Added "delete_accessions" command, which deletes all the accessions
in a given batch.

Any related entries in the "perfect_matches", "altered_md5_matches",
or "filename_only_matches" tables will also be deleted.

Added "ON DELETE CASCADE" to the accession id foreign key in the
following tables:

* perfect_matches
* altered_md5_matches
* filename_only_matches

Added tests to verify that "ON DELETE CASCADE" functions as expected
when deleting accessions via the ORM and "raw SQL" mechanisms.

Modified the SQLAlchemy Engine creation in "patsy/database.py" to
enable foreign key constraints in the SQLite database.

Added a "create_test_engine" method in "tests/utils.py" and modified
the test cases to use it, instead of instantiating the engine
individually.

https://issues.umd.edu/browse/LIBITD-1587