### PR TITLE
LIBITD-1942. Added "export_inventory" command to export database information

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,21 @@ parameter is required.
 
 ### Exporting Inventory Records for Patsy v2
 
-A "inventory" CSV file can be created for loading into a patsy v2 database
-with the following command:
+The "export_inventory" command exports CSV-formatted information in a
+format that can be loaded into a patsy v2 database.
+
+Before running the command, the "schema" commnd needs to be run once on
+the database to set up the necessary database views:
+
+```
+> python3 -m patsy --database <DATABASE> schema
+```
+
+where \<DATABASE> is the path to the SQLite database. This command only needs
+to be run once per database (if is safe to run more than once).
+
+The "inventory" CSV file can then be created for loading into a patsy v2
+database with the following command:
 
 ```
 > python3 -m patsy --database <DATABASE> export_inventory --batch <BATCH> --output <OUTPUT_FILE>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Command-line client for preservation asset tracking system (PATSy)
 
+## Project Branches
+
+This project uses the "GitHub Flow" branching model (see
+<https://confluence.umd.edu/display/LIB/GitHub+Flow+Model+for+Kubernetes+configuration+%28k8s-%29+repositories>)
+
+The "main" branch represents version 2 (v2) of the "patsy-db" codebase, which
+is incompatible with the "legacy" version 1 (v1) codebase.
+
+Any work on the legacy patsy-db v1 application should be performed on the
+"main-v1" branch.
+
 ## Prerequisites
 
 * Python 3.7
@@ -52,7 +63,7 @@ The following lists the known commands:
 ### Creating a new (empty) database
 
 ```
-> python3 -m patsy --database <DATABASE> schema 
+> python3 -m patsy --database <DATABASE> schema
 ```
 
 where `<DATABASE>` is one of:
@@ -220,7 +231,7 @@ The following fields will be output:
   once.
 * num_accessions_transferred: The number of accessions that have been
   transferred. Accessions that match multiple restore records which have been
-  transferred will only be counted once.  
+  transferred will only be counted once.
 
 ### Unmatched Accessions
 
@@ -286,6 +297,22 @@ will properly remove related entries in the "perfect_matches",
 where <DATABASE> is the path to the SQLite database, and \<BATCH> is
 a batch name (corresponding to the "batch" field in the accession). The \<BATCH>
 parameter is required.
+
+### Exporting Inventory Records for Patsy v2
+
+A "inventory" CSV file can be created for loading into a patsy v2 database
+with the following command:
+
+```
+> python3 -m patsy --database <DATABASE> export_inventory --batch <BATCH> --output <OUTPUT_FILE>
+```
+
+where \<DATABASE> is the path to the SQLite database, \<BATCH> is
+a batch name (corresponding to the "batch" field in the accession) and
+<OUTPUT_FILE> is the output filename for the CSV file containing the results.
+Both \<BATCH> and <OUTPUT_FILE> are optional. If \<BATCH> is not provided,
+information about all the batches will be output. If <OUTPUT_FILE> is not
+provided, the output will be printed to standard out.
 
 ## Accession Records
 

--- a/patsy/__main__.py
+++ b/patsy/__main__.py
@@ -8,6 +8,7 @@ from .accession import AccessionCsvLoader
 from .aws_manifest import create_manifest_command
 from .batch_stats import batch_stats_command
 from .database import create_schema
+from .export_inventory import export_inventory_command
 from .perfect_matches import find_perfect_matches_command
 from .altered_md5_matches import find_altered_md5_matches_command
 from .filename_only_matches import find_filename_only_matches_command
@@ -56,28 +57,28 @@ def get_args():
 
     # create the parser for the "schema" command
     schema_subcommand = subparsers.add_parser(
-        'schema', 
+        'schema',
         help='Create schema from the declarative base'
         )
 
     # create the parser for the "load_accessions" command
     accessions_subcommand = subparsers.add_parser(
-        'accessions', 
+        'accessions',
         help='Load accession records'
-        )    
+        )
     accessions_subcommand.add_argument(
-        '-s', '--source', 
+        '-s', '--source',
         action='store',
         help='Source of accessions to load'
         )
 
     # create the parser for the "load_restores" command
     restores_subcommand = subparsers.add_parser(
-        'restores', 
+        'restores',
         help='Load restored files table'
-        )    
+        )
     restores_subcommand.add_argument(
-        '-s', '--source', 
+        '-s', '--source',
         action='store',
         help='Source of restores to load'
         )
@@ -225,6 +226,25 @@ def get_args():
          help='filepath for generated .png file'
     )
 
+    export_inventory_subcommand = subparsers.add_parser(
+        'export_inventory',
+        help="Export all records as an 'inventory' manifest file"
+    )
+
+    export_inventory_subcommand.add_argument(
+        '-b', '--batch',
+        action='store',
+        default=None,
+        help='Optional batch name to query. Defaults to querying all batches'
+    )
+
+    export_inventory_subcommand.add_argument(
+        '-o', '--output',
+        action='store',
+        default=None,
+        help='The (optional) file to write the batch stats to in CSV format. Defaults to standard out'
+    )
+
     return parser.parse_args()
 
 
@@ -329,6 +349,12 @@ def main():
                 print(f"Created {file}")
         else:
             print("No files created")
+
+    elif args.cmd == "export_inventory":
+        use_database_file(args.database)
+        result = export_inventory_command(args.batch, args.output)
+        print("----- Export Inventory ----")
+        print(result)
 
     print(f"Actions complete!")
     if args.database == ':memory:':

--- a/patsy/export_inventory.py
+++ b/patsy/export_inventory.py
@@ -143,6 +143,12 @@ def export_row(writer, row, fields, storage_provider):
         row_dict[field] = row[index]
     path = row_dict['PATH']
     relpath = row_dict['RELPATH']
+    # A few patsy-db v1 entries do not have a RELPATH. In these cases,
+    # assign FILENAME to RELPATH
+    if not relpath:
+        row_dict['RELPATH'] = row_dict['FILENAME']
+        relpath = row_dict['FILENAME']
+
     row_dict["DIRECTORY"] = os.path.dirname(path)
     # Using RELPATH for extension, instead of PATH, because PATH may not be
     # present, while RELPATH is required.

--- a/patsy/export_inventory.py
+++ b/patsy/export_inventory.py
@@ -1,0 +1,193 @@
+import csv
+import os
+import sys
+from .database import Session
+from datetime import datetime
+from .utils import get_batch_names
+
+
+def export_inventory_command(batch, output=None):
+    """
+    Called by the CLI to perform the "export_inventory" command.
+    :param batch: The name of the batch to limit the search to.
+    :param output: The filepath to write the CVS file to.
+    """
+    session = Session()
+
+    if batch is None:
+        batch_list = get_batch_names(session)
+    else:
+        batch_list = [batch]
+
+    num_exported = export_inventory(session, batch_list, output)
+
+    session.commit()
+    session.close()
+
+    return f"Exported {num_exported} accessions."
+
+
+def export_inventory(session, batch_list, output=None):
+    """
+    Exports all the records in a format suitable for the patsy v2 "inventory"
+    manifest.
+
+    :param session: the Session in which to perform the query
+    :param output: The filepath to write the inventory manifest to
+    """
+    num_exported = 0
+    if output is None:
+        out = sys.stdout
+        num_exported = export_inventory_entries(session, out, batch_list)
+        return num_exported
+    else:
+        with open(output, mode='w') as file_stream:
+            num_exported = export_inventory_entries(session, file_stream, batch_list)
+        return num_exported
+
+
+def export_inventory_entries(session, file_stream, batch_list):
+    """
+    Appends CSV records for the given batch_list to the given file_stream
+
+    :param session: the Session in which to perform the query
+    :param file_stream: the I/O stream to write the entries to
+    :param batch_list: the list of batch names to query
+    :return: the number of exported entries
+    """
+    inventory_fields = [
+        'BATCH', 'PATH', 'DIRECTORY', 'RELPATH', 'FILENAME', 'EXTENSION',
+        'BYTES', 'MTIME', 'MODDATE', 'MD5', 'SHA1', 'SHA256',
+        'storageprovider', 'storagepath']
+
+    writer = csv.DictWriter(file_stream, fieldnames=inventory_fields, extrasaction='ignore')
+
+    writer.writeheader()
+
+    num_exported = 0
+    for batch in batch_list:
+        num_exported += export_transferred_accessions(session, writer, batch)
+        num_exported += export_untransferred_accessions(session, writer, batch)
+
+    return num_exported
+
+
+def export_transferred_accessions(session, writer, batch):
+    """
+    Appends CSV records for accessions with transfers for the given batch using
+    the provided writer.
+
+    :param session: the Session in which to perform the query
+    :param writer: the csv.DictWriter to write the entries to
+    :param batch: The batch to export
+    :return: the number of exported entries
+    """
+    num_exported = 0
+    engine = session.get_bind()
+    with engine.connect() as con:
+        select_fields = [
+            'BATCH', 'PATH', 'RELPATH', 'FILENAME', 'BYTES', 'timestamp', 'MD5', 'storagepath'
+        ]
+        select_phrase = ",".join(select_fields)
+        rs = con.execute(f"SELECT {select_phrase} FROM transferred_inventory_records WHERE BATCH=?", batch)
+
+        storage_provider = "AWS"
+        for row in rs:
+            export_row(writer, row, select_fields, storage_provider)
+            num_exported += 1
+
+    return num_exported
+
+
+def export_untransferred_accessions(session, writer, batch):
+    """
+    Appends CSV records for accessions without transfers for the given batch
+    using the provided writer.
+
+    :param session: the Session in which to perform the query
+    :param writer: the csv.DictWriter to write the entries to
+    :param batch: The batch to export
+    :return: the number of exported entries
+    """
+    num_exported = 0
+
+    engine = session.get_bind()
+    with engine.connect() as con:
+        select_fields = [
+            'BATCH', 'PATH', 'RELPATH', 'FILENAME', 'BYTES', 'timestamp', 'MD5', 'storagepath'
+        ]
+        select_phrase = ",".join(select_fields)
+        rs = con.execute(f"SELECT {select_phrase} FROM untransferred_inventory_records WHERE BATCH=?", batch)
+
+        storage_provider = ""  # No storage provider for untransferred records
+        for row in rs:
+            export_row(writer, row, select_fields, storage_provider)
+            num_exported += 1
+
+    return num_exported
+
+
+def export_row(writer, row, fields, storage_provider):
+    """
+    Writes a single CSV line to the given cvs.DictWriter using the given fields
+    with the information provided by the row.
+
+    :param writer: the csv.DictWriter to write the entries to
+    :param row: A Dictionary containing the information to export
+    :fields: A list containing the fields to include in the CSV output
+    :storage_provider: the string to use for the "storage_provider" field in
+                       the output
+    """
+    row_dict = {}
+    for index, field in enumerate(fields):
+        row_dict[field] = row[index]
+    path = row_dict['PATH']
+    relpath = row_dict['RELPATH']
+    row_dict["DIRECTORY"] = os.path.dirname(path)
+    # Using RELPATH for extension, instead of PATH, because PATH may not be
+    # present, while RELPATH is required.
+    row_dict["EXTENSION"] = os.path.splitext(relpath)[1].lstrip('.').upper()
+
+    timestamp = row_dict["timestamp"]
+    timestamp_dict = handle_timestamp(timestamp)
+    row_dict.update(timestamp_dict)
+
+    row_dict["SHA1"] = ""
+    row_dict["SHA256"] = ""
+    row_dict["storageprovider"] = storage_provider
+    row_dict
+    writer.writerow(row_dict)
+
+
+def handle_timestamp(timestamp):
+    timestamp_dict = {}
+    timestamp_dict["MTIME"] = ""
+    timestamp_dict["MODDATE"] = ""
+
+    if not timestamp or timestamp == "":
+        return timestamp_dict
+
+    timestamp_formats = [
+        "%a %b %d %H:%M:%S %Z %Y",  # "Tue Aug 18 15:20:38 EDT 2015"
+        "%Y-%m-%dT%H:%M:%S",        # "2011-02-09T14:09:00"
+        "%Y-%m-%d %H:%M:%S",        # "2013-04-16 02:22:33"
+        "%m/%d/%Y %H:%M"            # "11/11/2009 17:33"
+    ]
+
+    modification_time = None
+    for format in timestamp_formats:
+        try:
+            modification_time = datetime.strptime(timestamp, format)
+            break
+        except ValueError:
+            continue
+
+    if modification_time:
+        seconds_since_epoch = modification_time.timestamp()
+        timestamp_dict["MTIME"] = seconds_since_epoch
+        mod_time = modification_time.strftime('%Y-%m-%dT%H:%M:%S')
+        timestamp_dict["MODDATE"] = mod_time
+    else:
+        print(f'WARNING -- Timestamp in unknown format: "{timestamp}"')
+
+    return timestamp_dict

--- a/tests/test_export_inventory.py
+++ b/tests/test_export_inventory.py
@@ -1,0 +1,51 @@
+import unittest
+from patsy.export_inventory import handle_timestamp
+
+
+class TestExportInventory(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_handle_timestamp__none(self):
+        timestamp = None
+
+        timestamp_dict = handle_timestamp(timestamp)
+
+        self.assertEqual("", timestamp_dict["MTIME"])
+        self.assertEqual("", timestamp_dict["MODDATE"])
+
+    def test_handle_timestamp__empty_string(self):
+        timestamp = None
+
+        timestamp_dict = handle_timestamp(timestamp)
+
+        self.assertEqual("", timestamp_dict["MTIME"])
+        self.assertEqual("", timestamp_dict["MODDATE"])
+
+    def test_handle_timestamp__various_formats(self):
+        timestamp_tests = []
+        timestamp_tests.append({
+            "timestamp": "Tue Aug 18 15:20:38 EDT 2015",
+            "expected_mtime": 1439925638.0,
+            "expected_moddate": "2015-08-18T15:20:38"
+        })
+        timestamp_tests.append({
+            "timestamp": "2011-02-09T14:09:00",
+            "expected_mtime": 1297278540.0,
+            "expected_moddate": '2011-02-09T14:09:00'
+        })
+        timestamp_tests.append({
+            "timestamp": "2013-04-16 02:22:33",
+            "expected_mtime": 1366093353.0,
+            "expected_moddate": '2013-04-16T02:22:33'
+        })
+        timestamp_tests.append({
+            "timestamp": "11/11/2009 17:33",
+            "expected_mtime": 1257978780.0,
+            "expected_moddate": '2009-11-11T17:33:00'
+        })
+
+        for test in timestamp_tests:
+            timestamp_dict = handle_timestamp(test["timestamp"])
+            self.assertEqual(test["expected_mtime"], timestamp_dict["MTIME"])
+            self.assertEqual(test["expected_moddate"], timestamp_dict["MODDATE"])


### PR DESCRIPTION
Added an "export_inventory" command to export accessions (both transferred and untransferred) into a CSV file suitable for loading into patsy-v2.

Updated the database schema to create "transferred_inventory_records" and "untransferred_inventory_records" views for use by the "export_inventory" command.

https://issues.umd.edu/browse/LIBITD-1942