### PR TITLE
add "untransferred" option to export command

### DIFF
--- a/patsy/commands/export.py
+++ b/patsy/commands/export.py
@@ -30,16 +30,25 @@ def configure_cli(subparsers) -> None:  # type: ignore
         help='The (optional) file to write output to. Defaults to standard out'
     )
 
+    parser.add_argument(
+        '-u', '--untransferred',
+        action='store_true',
+        default=False,
+        help='Export only those records with an empty storage_location.'
+    )
+
 
 class Command(patsy.core.command.Command):
     def __call__(self, args: argparse.Namespace, gateway: DbGateway) -> str:
         batch = args.batch
         output = args.output
+        untransferred = args.untransferred
         # Display batch configuration information to the user
         sys.stderr.write(
             f'Running export command with the following options:\n\n'
             f'  - batch: {batch}\n'
             f'  - output: {output}\n'
+            f'  - untransferred: {untransferred}\n'
             '======\n'
         )
 

--- a/patsy/commands/export.py
+++ b/patsy/commands/export.py
@@ -42,20 +42,21 @@ class Command(patsy.core.command.Command):
     def __call__(self, args: argparse.Namespace, gateway: DbGateway) -> str:
         batch = args.batch
         output = args.output
-        untransferred = args.untransferred
+        filter = args.untransferred
         # Display batch configuration information to the user
         sys.stderr.write(
             f'Running export command with the following options:\n\n'
             f'  - batch: {batch}\n'
             f'  - output: {output}\n'
-            f'  - untransferred: {untransferred}\n'
+            f'  - untransferred: {filter}\n'
             '======\n'
         )
 
         export_impl = Export(gateway)
-        export_result = export_impl.export(batch, output)
+        export_result = export_impl.export(batch, output, filter)
         result_messages = [
-            f"Total (non-empty) Batches exported: {export_result.batches_exported}",
+            f"Total (non-empty) Batches exported: " +
+            f"{export_result.batches_exported}",
             f"Total rows exported: {export_result.rows_exported}",
             "\nEXPORT COMPLETE"
         ]

--- a/patsy/core/db_gateway.py
+++ b/patsy/core/db_gateway.py
@@ -20,7 +20,6 @@ class DbGateway():
         use_database_file(args.database)
         self.session = Session()
         self.batch_ids: Dict[str, int] = {}
-        self.filter_untransferred = args.untransferred
 
     def add(self, patsy_record: PatsyRecord) -> AddResult:
         self.add_result = AddResult()
@@ -107,7 +106,9 @@ class DbGateway():
         """
         return cast(Optional[Batch], self.session.query(Batch).filter(Batch.name == name).first())
 
-    def get_batch_records(self, batch_name: str) -> List[PatsyRecord]:
+    def get_batch_records(
+            self, batch_name: str, untransferred_only=False
+            ) -> List[PatsyRecord]:
         """
         Returns a (possibly empty) List of PatsyRecord objects representing the
         data from the given batch.
@@ -118,11 +119,11 @@ class DbGateway():
         SQL_PATSY_RECORD_BY_NAME = \
             "SELECT * FROM patsy_records WHERE batch_name=:batch_name"
         SQL_PATSY_RECORD_BY_NAME_UNTRANSFERRED = \
-            '''SELECT * FROM patsy_records 
+            '''SELECT * FROM patsy_records
                 WHERE batch_name=:batch_name
                 AND storage_location IS NULL'''
 
-        if self.filter_untransferred:
+        if untransferred_only:
             sql_stmt = text(SQL_PATSY_RECORD_BY_NAME_UNTRANSFERRED)
         else:
             sql_stmt = text(SQL_PATSY_RECORD_BY_NAME)

--- a/patsy/core/db_gateway.py
+++ b/patsy/core/db_gateway.py
@@ -20,6 +20,7 @@ class DbGateway():
         use_database_file(args.database)
         self.session = Session()
         self.batch_ids: Dict[str, int] = {}
+        self.filter_untransferred = args.untransferred
 
     def add(self, patsy_record: PatsyRecord) -> AddResult:
         self.add_result = AddResult()
@@ -116,7 +117,15 @@ class DbGateway():
         """
         SQL_PATSY_RECORD_BY_NAME = \
             "SELECT * FROM patsy_records WHERE batch_name=:batch_name"
-        sql_stmt = text(SQL_PATSY_RECORD_BY_NAME)
+        SQL_PATSY_RECORD_BY_NAME_UNTRANSFERRED = \
+            '''SELECT * FROM patsy_records 
+                WHERE batch_name=:batch_name
+                AND storage_location IS NULL'''
+
+        if self.filter_untransferred:
+            sql_stmt = text(SQL_PATSY_RECORD_BY_NAME_UNTRANSFERRED)
+        else:
+            sql_stmt = text(SQL_PATSY_RECORD_BY_NAME)
         sql_stmt = sql_stmt.bindparams(batch_name=batch_name)
 
         patsy_records: List[PatsyRecord] = []

--- a/patsy/core/export.py
+++ b/patsy/core/export.py
@@ -29,7 +29,7 @@ class Export:
         self.gateway = gateway
         self.export_result = ExportResult()
 
-    def export(self, batch: str, output: str) -> ExportResult:
+    def export(self, batch: str, output: str, untransferred: bool) -> ExportResult:
         batch_list = []
 
         if batch is None:
@@ -40,15 +40,16 @@ class Export:
 
         if output is None:
             out = sys.stdout
-            self.export_entries(batch_list, out)
+            self.export_entries(batch_list, out, filter)
             return self.export_result
         else:
             with open(output, mode='w') as file_stream:
-                self.export_entries(batch_list, file_stream)
+                self.export_entries(batch_list, file_stream, untransferred)
             return self.export_result
 
-    def export_entries(self, batch_list: List[str], file_stream: TextIO) -> None:
-        if self.gateway.filter_untransferred:
+    def export_entries(self, batch_list: List[str],
+                       file_stream: TextIO, untransferred: bool) -> None:
+        if untransferred:
             fieldnames = Load.TRANSFER_MANIFEST_CSV_FIELDS
         else:
             fieldnames = Load.ALL_CSV_FIELDS
@@ -58,7 +59,7 @@ class Export:
         writer.writeheader()
 
         for b in batch_list:
-            batch_records = self.gateway.get_batch_records(b)
+            batch_records = self.gateway.get_batch_records(b, untransferred)
             if len(batch_records) > 0:
                 self.export_result.batches_exported += 1
             for patsy_record in batch_records:

--- a/patsy/core/export.py
+++ b/patsy/core/export.py
@@ -48,9 +48,15 @@ class Export:
             return self.export_result
 
     def export_entries(self, batch_list: List[str], file_stream: TextIO) -> None:
-        writer = csv.DictWriter(file_stream, fieldnames=Load.ALL_CSV_FIELDS, extrasaction='ignore')
-
+        if self.gateway.filter_untransferred:
+            fieldnames = Load.TRANSFER_MANIFEST_CSV_FIELDS
+        else:
+            fieldnames = Load.ALL_CSV_FIELDS
+        writer = csv.DictWriter(
+                    file_stream, fieldnames=fieldnames, extrasaction='ignore'
+                    )
         writer.writeheader()
+
         for b in batch_list:
             batch_records = self.gateway.get_batch_records(b)
             if len(batch_records) > 0:

--- a/patsy/core/load.py
+++ b/patsy/core/load.py
@@ -25,16 +25,19 @@ class LoadResult():
 
 
 class Load:
-    ALL_CSV_FIELDS = [
+    TRANSFER_MANIFEST_CSV_FIELDS = [
         'BATCH', 'PATH', 'DIRECTORY', 'RELPATH', 'FILENAME', 'EXTENSION',
-        'BYTES', 'MTIME', 'MODDATE', 'MD5', 'SHA1', 'SHA256',
-        'storageprovider', 'storagepath'
+        'BYTES', 'MTIME', 'MODDATE', 'MD5', 'SHA1', 'SHA256'
     ]
+
+    # The following fields are not required in the CSV file
+    ALLOWED_MISSING_FIELDS = ['storageprovider', 'storagepath']
+
+    ALL_CSV_FIELDS = TRANSFER_MANIFEST_CSV_FIELDS + ALLOWED_MISSING_FIELDS
 
     # Fields that must be present in the CSV, with non-empty content
     REQUIRED_CONTENT_CSV_FIELDS = [
-        'BATCH', 'RELPATH', 'FILENAME', 'BYTES', 'MD5',
-
+        'BATCH', 'RELPATH', 'FILENAME', 'BYTES', 'MD5'
     ]
 
     # Fields that must be present, but may be empty
@@ -44,10 +47,6 @@ class Load:
 
     REQUIRED_CSV_FIELDS = REQUIRED_CONTENT_CSV_FIELDS + ALLOWED_EMPTY_CSV_FIELDS
 
-    # The following fields are not required in the CSV file
-    ALLOWED_MISSING_FIELDS = [
-        'storageprovider', 'storagepath'
-    ]
 
     def __init__(self, gateway: DbGateway) -> None:
         self.gateway = gateway

--- a/patsy/core/load.py
+++ b/patsy/core/load.py
@@ -20,7 +20,6 @@ class LoadResult():
             f"locations_added='{self.locations_added}'",
             f"errors='{self.errors}'"
         ]
-
         return f"<LoadResult({','.join(lines)})>"
 
 
@@ -47,7 +46,6 @@ class Load:
 
     REQUIRED_CSV_FIELDS = REQUIRED_CONTENT_CSV_FIELDS + ALLOWED_EMPTY_CSV_FIELDS
 
-
     def __init__(self, gateway: DbGateway) -> None:
         self.gateway = gateway
         self.load_result = LoadResult()
@@ -63,20 +61,27 @@ class Load:
                 csv_line_index += 1
 
                 if add_result:
-                    self.load_result.batches_added += add_result.batches_added
-                    self.load_result.accessions_added += add_result.accessions_added
-                    self.load_result.locations_added += add_result.locations_added
+                    self.load_result.batches_added += \
+                        add_result.batches_added
+                    self.load_result.accessions_added += \
+                        add_result.accessions_added
+                    self.load_result.locations_added += \
+                        add_result.locations_added
 
         return self.load_result
 
-    def process_csv_row(self, csv_line_index: int, row: Dict[str, str]) -> Optional[AddResult]:
+    def process_csv_row(
+            self, csv_line_index: int, row: Dict[str, str]
+            ) -> Optional[AddResult]:
         if not self.is_row_valid(csv_line_index, row):
             return None
 
         patsy_record = PatsyUtils.from_inventory_csv(row)
         return self.gateway.add(patsy_record)
 
-    def is_row_valid(self, csv_line_index: int, row_dict: Dict[str, str]) -> bool:
+    def is_row_valid(
+            self, csv_line_index: int, row_dict: Dict[str, str]
+            ) -> bool:
         """
         Returns True if the given row is valid, False otherwise.
         """
@@ -94,7 +99,8 @@ class Load:
 
         if missing_fields or missing_values:
             self.load_result.errors.append(
-                f"Line {csv_line_index}, missing_fields: {missing_fields}, missing_values = {missing_values}"
+                f"Line {csv_line_index}, missing_fields:" +
+                f" {missing_fields}, missing_values = {missing_values}"
             )
             return False
         return True

--- a/patsy/database.py
+++ b/patsy/database.py
@@ -12,18 +12,18 @@ Session = sessionmaker()
 def use_database_file(database: str) -> None:
     # Set up database file or use in-memory db
     if database == ":memory:":
-        sys.stderr.write(f"Using a transient in-memory database...")
+        sys.stderr.write(f"Using a transient in-memory database...\n")
         db_path = f"sqlite:///{database}"
 
     elif database.startswith('postgresql:'):
-        sys.stderr.write(f"Using postgres database at {database}")
+        sys.stderr.write(f"Using postgres database at {database}\n")
         db_path = database
 
     else:
-        sys.stderr.write(f"Using database at {database}...")
+        sys.stderr.write(f"Using database at {database}...\n")
         db_path = f"sqlite:///{database}"
 
-    sys.stderr.write("Binding the database session...")
+    sys.stderr.write("Binding the database session...\n")
 
     engine = create_engine(db_path)
 


### PR DESCRIPTION
Adds the ability to restrict an export to records with null values in the storage_location field. Also removes storageprovider and storagepath from the export CSV as those columns are not allowed by aws-archiver when running a transfer. This option simulates the create_manifest command of PATSy v1.