### PR TITLE
LIBAVALON-185. Added "checksum" command to patsy CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ the accession (even if the accession information in the CSV file is different).
 Location information for an existing accession will be added, unless the
 location already exists for that accession.
 
+### "checksum" command
+
+Retrieves checksums (MD5 (default), SHA1, or SHA256) for one or more accessions,
+looked up by storage location.
+
+```
+> patsy --database <DATABASE> checksum [--md5|--sha1|--sha256] [LOCATION [LOCATIONS...]]
+```
+
+Creates output like this:
+
+```
+088be3fe9a8fd2a7e70e66a602828766  libdc-archivebucket-17lowbw7m2av1/Archive000Florence/Florence.mpg
+fe84e91e0a06906773a5c19a2e9620d9  libdc-archivebucket-17lowbw7m2av1/Archive000Football1/19461130-FB-002-2Qtr.mpg
+9876f8c92e16b73c662a39b23409d0a0  libdc-archivebucket-17lowbw7m2av1/Archive000Football1/19461130-FB-003-2Half.mpg
+```
+
+Instead of listing locations on the command line, the checksum command
+also accepts a CSV file with columns "location" and "destination". If
+the "destination" is present, it is used for the second column. Assuming
+that the "destination" refers to an actual path on a local file
+system, this output can then be fed to `md5sum -c` (or other 
+algorithm-appropriate checksum verification tool).
+
+```
+> patsy --database <DATABASE> checksum [--md5|--sha1|--sha256] --file <CSV_FILE>
+```
+
 ## License
 
 See the [LICENSE](LICENSE) file for license rights and limitations.

--- a/patsy/commands/checksum.py
+++ b/patsy/commands/checksum.py
@@ -1,0 +1,92 @@
+import argparse
+import csv
+import sys
+from typing import Mapping, Optional, Tuple
+
+import patsy.core.command
+from patsy.core.db_gateway import DbGateway
+
+
+def configure_cli(subparsers) -> None:  # type: ignore
+    """
+    Configures the CLI arguments for this command
+    """
+    parser = subparsers.add_parser(
+        name='checksum',
+        description='Look up accession checksum by storage location'
+    )
+    parser.add_argument(
+        '-f', '--file',
+        type=argparse.FileType(),
+        dest='locations_file',
+        help='CSV file containing locations to look up'
+    )
+    parser.add_argument(
+        '-o', '--output-file',
+        type=argparse.FileType(mode='w'),
+        default=sys.stdout,
+        help='file to write checksums to; defaults to STDOUT'
+    )
+    checksum_type_parser = parser.add_mutually_exclusive_group()
+    checksum_type_parser.add_argument(
+        '--md5',
+        dest='output_type',
+        action='store_const',
+        const='md5',
+        help='retrieve MD5 checksum'
+    )
+    checksum_type_parser.add_argument(
+        '--sha1',
+        dest='output_type',
+        action='store_const',
+        const='sha1',
+        help='retrieve SHA1 checksum'
+    )
+    checksum_type_parser.add_argument(
+        '--sha256',
+        dest='output_type',
+        action='store_const',
+        const='sha256',
+        help='retrieve SHA256 checksum'
+    )
+    parser.add_argument(
+        'location',
+        nargs='*',
+        default=[]
+    )
+    parser.set_defaults(cmd_name='checksum')
+
+
+def get_checksum(gateway: DbGateway, row: Mapping[str, str], checksum_type: str) -> Optional[Tuple[str, str]]:
+    location = row['location']
+    accession = gateway.get_accession_by_location(location)
+    # default to using the location in the output if there is no separate destination value
+    destination = row.get('destination', location)
+    if accession is not None:
+        if checksum_type == 'md5' and accession.md5:
+            return accession.md5, destination
+        elif checksum_type == 'sha1' and accession.sha1:
+            return accession.sha1, destination
+        elif checksum_type == 'sha256' and accession.sha256:
+            return accession.sha256, destination
+        else:
+            sys.stderr.write(f'No {checksum_type.upper()} checksum found for "{row["location"]}"\n')
+    else:
+        sys.stderr.write(f'No accession record found for "{row["location"]}"\n')
+
+
+class Command(patsy.core.command.Command):
+    def __call__(self, args: argparse.Namespace, gateway: DbGateway) -> str:
+        if args.output_type is None:
+            args.output_type = 'md5'
+
+        if getattr(args, 'locations_file', None) is not None:
+            locations = csv.DictReader(args.locations_file)
+        else:
+            locations = [{'location': location} for location in args.location]
+        for row in locations:
+            checksum_and_path = get_checksum(gateway=gateway, row=row, checksum_type=args.output_type)
+            if checksum_and_path:
+                print('  '.join(checksum_and_path), file=args.output_file)
+
+        return ''

--- a/patsy/commands/checksum.py
+++ b/patsy/commands/checksum.py
@@ -1,7 +1,7 @@
 import argparse
 import csv
 import sys
-from typing import Mapping, Optional, Tuple
+from typing import Dict, Iterable, Mapping, Optional, Tuple
 
 import patsy.core.command
 from patsy.core.db_gateway import DbGateway
@@ -73,6 +73,7 @@ def get_checksum(gateway: DbGateway, row: Mapping[str, str], checksum_type: str)
             sys.stderr.write(f'No {checksum_type.upper()} checksum found for "{row["location"]}"\n')
     else:
         sys.stderr.write(f'No accession record found for "{row["location"]}"\n')
+    return None
 
 
 class Command(patsy.core.command.Command):
@@ -81,7 +82,7 @@ class Command(patsy.core.command.Command):
             args.output_type = 'md5'
 
         if getattr(args, 'locations_file', None) is not None:
-            locations = csv.DictReader(args.locations_file)
+            locations: Iterable[Dict[str, str]] = csv.DictReader(args.locations_file)
         else:
             locations = [{'location': location} for location in args.location]
         for row in locations:

--- a/patsy/core/db_gateway.py
+++ b/patsy/core/db_gateway.py
@@ -92,6 +92,13 @@ class DbGateway():
 
         return location
 
+    def get_accession_by_location(self, location: str) -> Optional[Accession]:
+        """
+        Returns the Accession with the given location.
+        """
+        result = self.session.query(Accession).join(Location.accessions).filter(Location.storage_location == location)
+        return cast(Optional[Accession], result.first())
+
     def get_all_batches(self) -> List[Batch]:
         """
         Returns a list of all the batches in the database.

--- a/tests/fixtures/checksum/locations_file.csv
+++ b/tests/fixtures/checksum/locations_file.csv
@@ -1,0 +1,3 @@
+location
+test_bucket/TEST_BATCH/colors/sample_blue.jpg
+test_bucket/TEST_BATCH/colors/sample_red.jpg

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -1,0 +1,135 @@
+import io
+import os
+import tempfile
+import unittest
+from argparse import Namespace
+from patsy.commands.checksum import Command, get_checksum
+from patsy.core.schema import Schema
+from patsy.core.db_gateway import DbGateway
+from patsy.core.load import Load
+from unittest.mock import patch
+
+
+class TestChecksumCommand(unittest.TestCase):
+    def setUp(self):
+        args = Namespace()
+        args.database = ":memory:"
+        self.gateway = DbGateway(args)
+        schema = Schema(self.gateway)
+        schema.create_schema()
+        self.load = Load(self.gateway)
+
+        csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
+
+        self.load.process_file(csv_file)
+
+        self.checksum_command = Command()
+        # Arguments passed to checksum.Command
+        self.command_args = Namespace()
+        self.command_args.location = None
+        self.command_args.output_type = None
+        self.command_args.output_file = None
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_location_arg(self, mock_out):
+        self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
+
+        self.checksum_command.__call__(self.command_args, self.gateway)
+        expected = '85a929103d2f58ddfa8c8768eb6339ad  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n'
+        self.assertEqual(expected, mock_out.getvalue())
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_output_type_arg(self, mock_out):
+        self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
+        self.command_args.output_type = 'sha1'
+
+        self.checksum_command.__call__(self.command_args, self.gateway)
+        expected = '2fa953a48600e1aef0486b4b3a17c6100cfeef80  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n'
+        self.assertEqual(expected, mock_out.getvalue())
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_locations_file_arg(self, mock_out):
+        with open('tests/fixtures/checksum/locations_file.csv') as f:
+            self.command_args.locations_file = f
+
+            self.checksum_command.__call__(self.command_args, self.gateway)
+
+            expected = '85a929103d2f58ddfa8c8768eb6339ad  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n' \
+                       '1041fd1cf84c71183db2d5d95942a41c  test_bucket/TEST_BATCH/colors/sample_red.jpg\n'
+            self.assertEqual(expected, mock_out.getvalue())
+
+    def test_output_file_arg(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            output_filename = os.path.join(tmpdirname, 'test_output_file.csv')
+            with open(output_filename, 'w') as output_file:
+                self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
+                self.command_args.output_file = output_file
+
+                self.checksum_command.__call__(self.command_args, self.gateway)
+
+            self.assertEqual(80, os.path.getsize(output_filename))
+
+
+class TestGetChecksum(unittest.TestCase):
+    def setUp(self):
+        args = Namespace()
+        args.database = ":memory:"
+        self.gateway = DbGateway(args)
+        schema = Schema(self.gateway)
+        schema.create_schema()
+        self.load = Load(self.gateway)
+
+        csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
+
+        self.load.process_file(csv_file)
+
+    def test_valid_row_and_md5_checksum__returns_tuple(self):
+        row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
+        expected = ('85a929103d2f58ddfa8c8768eb6339ad', 'test_bucket/TEST_BATCH/colors/sample_blue.jpg')
+
+        checksum_and_path = get_checksum(self.gateway, row, 'md5')
+        self.assertEqual(expected, checksum_and_path)
+
+    def test_valid_row_and_sha1_checksum__returns_tuple(self):
+        row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
+        expected = ('2fa953a48600e1aef0486b4b3a17c6100cfeef80', 'test_bucket/TEST_BATCH/colors/sample_blue.jpg')
+
+        checksum_and_path = get_checksum(self.gateway, row, 'sha1')
+        self.assertEqual(expected, checksum_and_path)
+
+    def test_gvalid_row_and_sha256_checksum__returns_tuple(self):
+        row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
+        expected = (
+            'e80dd1c34dbdc98521138eacc0e921683d8c9970a1f7cfe75bbfff56d5638238',
+            'test_bucket/TEST_BATCH/colors/sample_blue.jpg'
+        )
+
+        checksum_and_path = get_checksum(self.gateway, row, 'sha256')
+        self.assertEqual(expected, checksum_and_path)
+
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_location_not_found_returns__None_and_displays_error(self, mock_err):
+        row = {'location': 'not_a_location_in_database'}
+
+        checksum_and_path = get_checksum(self.gateway, row, 'md5')
+        self.assertIsNone(checksum_and_path)
+        self.assertRegex(mock_err.getvalue(), r"No accession record found for .*")
+
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_checksum_type_not_found_returns__None_and_displays_error(self, mock_err):
+        row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
+        checksum_type = 'invalid_type'
+
+        checksum_and_path = get_checksum(self.gateway, row, checksum_type)
+        self.assertIsNone(checksum_and_path)
+        self.assertRegex(mock_err.getvalue(), r"No INVALID_TYPE checksum found .*")
+
+    def test_tuple_contains_destination_if_provided(self):
+        row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg', 'destination': 'DESTINATION'}
+        expected = ('85a929103d2f58ddfa8c8768eb6339ad', 'DESTINATION')
+
+        checksum_and_path = get_checksum(self.gateway, row, 'md5')
+        self.assertEqual(expected, checksum_and_path)
+
+    def tearDown(self):
+        self.gateway.close()


### PR DESCRIPTION
Look up one or more accessions by storage location, and return md5 (default), sha1, or sha256 checksums. With a "--file" option, takes a CSV file with "location" and "destination" columns, and returns md5sum-style output with "{checksum}  {destination}" lines.

https://issues.umd.edu/browse/LIBAVALON-185