### PR TITLE
LIBITD-1754. Migrate patsy-db from SQLite to PostgreSQL

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,20 @@
+# Dockerfile for use by the continuous integration server (ci), in order to
+# build and test the application.
+#
+# This Dockerfile provides the appropriate environment for building and testing
+# the application. It should _not_ be used for creating Docker images for use
+# in production.
+
+FROM python:3.7.13-slim
+
+RUN apt-get update && \
+    apt-get install -y build-essential && \
+    apt-get install -y git && \
+    apt-get install -y lsb-release && \
+    apt-get install -y wget && \
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get -y install postgresql && \
+    apt-get -y install libpq-dev && \
+    apt-get clean

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,167 @@
+pipeline {
+  // Jenkins configuration dependencies
+  //
+  //   Global Tool Configuration:
+  //     Git
+  //
+  // This configuration utilizes the following Jenkins plugins:
+  //
+  //   * Warnings Next Generation
+  //   * Email Extension Plugin
+  //
+  // This configuration also expects the following environment variables
+  // to be set (typically in /apps/ci/config/env:
+  //
+  // JENKINS_EMAIL_SUBJECT_PREFIX
+  //     The Email subject prefix identifying the server.
+  //     Typically "[Jenkins - <HOSTNAME>]" where <HOSTNAME>
+  //     is the name of the server, i.e. "[Jenkins - cidev]"
+  //
+  // JENKINS_DEFAULT_EMAIL_RECIPIENTS
+  //     A comma-separated list of email addresses that should
+  //    be the default recipients of Jenkins emails.
+
+  agent {
+    dockerfile {
+      filename 'Dockerfile.ci'
+      // Pass JENKINS_EMAIL_SUBJECT_PREFIX and JENKINS_DEFAULT_EMAIL_RECIPIENTS
+      // into container as "env" arguments, so they are available inside the
+      // Docker container
+      args '-u root --env JENKINS_DEFAULT_EMAIL_RECIPIENTS=$JENKINS_DEFAULT_EMAIL_RECIPIENTS --env JENKINS_EMAIL_SUBJECT_PREFIX=$JENKINS_EMAIL_SUBJECT_PREFIX'
+    }
+  }
+
+  options {
+    buildDiscarder(
+      logRotator(
+        artifactDaysToKeepStr: '',
+        artifactNumToKeepStr: '',
+        numToKeepStr: '20'))
+  }
+
+  environment {
+    DEFAULT_RECIPIENTS = "${ \
+      sh(returnStdout: true, \
+         script: 'echo $JENKINS_DEFAULT_EMAIL_RECIPIENTS').trim() \
+    }"
+
+    EMAIL_SUBJECT_PREFIX = "${ \
+      sh(returnStdout: true, script: 'echo $JENKINS_EMAIL_SUBJECT_PREFIX').trim() \
+    }"
+
+    EMAIL_SUBJECT = "$EMAIL_SUBJECT_PREFIX - " +
+                    '$PROJECT_NAME - ' +
+                    'GIT_BRANCH_PLACEHOLDER - ' +
+                    '$BUILD_STATUS! - ' +
+                    "Build # $BUILD_NUMBER"
+
+    EMAIL_CONTENT =
+        '''$PROJECT_NAME - GIT_BRANCH_PLACEHOLDER - $BUILD_STATUS! - Build # $BUILD_NUMBER:
+           |
+           |Check console output at $BUILD_URL to view the results.
+           |
+           |There are ${ANALYSIS_ISSUES_COUNT} static analysis issues in this build.
+           |
+           |There were ${TEST_COUNTS,var="skip"} skipped tests.'''.stripMargin()
+  }
+
+  stages {
+    stage('initialize') {
+      steps {
+        script {
+          // Retrieve the actual Git branch being built for use in email.
+          //
+          // For pull requests, the actual Git branch will be in the
+          // CHANGE_BRANCH environment variable.
+          //
+          // For actual branch builds, the CHANGE_BRANCH variable won't exist
+          // (and an exception will be thrown) but the branch name will be
+          // part of the PROJECT_NAME variable, so it is not needed.
+
+          ACTUAL_GIT_BRANCH = ''
+
+          try {
+            ACTUAL_GIT_BRANCH = CHANGE_BRANCH + ' - '
+          } catch (groovy.lang.MissingPropertyException mpe) {
+            // Do nothing. A branch (as opposed to a pull request) is being
+            // built
+          }
+
+          // Replace the "GIT_BRANCH_PLACEHOLDER" in email variables
+          EMAIL_SUBJECT = EMAIL_SUBJECT.replaceAll('GIT_BRANCH_PLACEHOLDER - ', ACTUAL_GIT_BRANCH )
+          EMAIL_CONTENT = EMAIL_CONTENT.replaceAll('GIT_BRANCH_PLACEHOLDER - ', ACTUAL_GIT_BRANCH )
+        }
+      }
+    }
+
+    stage('build') {
+      steps {
+        sh '''
+          pip install -e .[dev,test]
+        '''
+      }
+    }
+
+    stage('test') {
+      steps {
+        sh '''
+          # Install pytest
+          pip install pytest
+
+          pytest --cov-report xml:reports/coverage.xml --cov=patsy -v --junitxml=reports/results.xml -o junit_family=xunit1
+        '''
+      }
+      post {
+        always {
+          junit '**/reports/results.xml'
+
+          cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, zoomCoverageChart: false
+        }
+      }
+    }
+
+    stage('static-analysis') {
+      steps {
+        sh '''
+          # Install pycodestyle
+          pip install pycodestyle
+
+          # Run pycodestyle
+          # Send output to standard out for "Record compiler warnings and static analysis results"
+          # post-build action
+          #
+          # Using "|| true" so that build will be considered successful, even if there are violations.
+          pycodestyle --format pylint patsy tests || true
+        '''
+      }
+      post {
+        always {
+          // Collect pycodestyle reports
+          recordIssues(tools: [pyLint(reportEncoding: 'UTF-8', name: 'pycodestyle')], unstableTotalAll: 1)
+        }
+      }
+    }
+
+    stage('clean-workspace') {
+      steps {
+        // Change permissions of the workspace directory to world-writeable
+        // so Jenkins can delete it. This is needed, because files may be
+        // written to the directory from the Docker container as the "root"
+        // user, which Jenkins would not otherwise be able to clean up.
+        sh '''
+          chmod --recursive 777 $WORKSPACE
+        '''
+
+        cleanWs()
+      }
+    }
+  }
+
+  post {
+    always {
+      emailext to: "$DEFAULT_RECIPIENTS",
+               subject: "$EMAIL_SUBJECT",
+               body: "$EMAIL_CONTENT"
+    }
+  }
+}

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        '--base-url',
+        action='store',
+        default=':memory:',
+        help='Base Database URL for the tests'
+    )

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -56,6 +56,11 @@ To run the tests:
 > pytest
 ```
 
+For running the test with Postgres, create a docker container with Postgres first.
+```
+> docker run -d -p 5432:5432 --name test -e POSTGRES_PASSWORD=password postgres
+```
+
 ## Code Style
 
 Application code style should generally conform to the guidelines in

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -50,17 +50,22 @@ Once "pyenv" and "pyenv-virtualenv" have been installed, install Python 3.7.10:
 
 ## Running The Tests
 
-First create a docker container with Postgres first.
+```
+> pytest
+```
+
+By default, running pytest will run the test in an Sqlite in memory database.
+To run the test against a Postgres database, first create a docker container with
+Postgres.
 
 ```
 > docker run -d -p 5432:5432 --name test -e POSTGRES_PASSWORD=password postgres
 ```
 
-Then run pytest, which will run all test twice,
-with a Sqlite database and a Postgres database
+Then run pytest with this additional parameter
 
 ```
-> pytest
+> pytest --base-url="postgresql+psycopg2://postgres:password@localhost:5432/postgres"
 ```
 
 ## Test Coverage Report

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -21,7 +21,7 @@ Once "pyenv" and "pyenv-virtualenv" have been installed, install Python 3.7.10:
 > pyenv install 3.7.10 --skip-existing
 ```
 
-## Installation for development
+## Installation for Development
 
 1) Clone the "patsy-db" Git repository:
 
@@ -48,7 +48,7 @@ Once "pyenv" and "pyenv-virtualenv" have been installed, install Python 3.7.10:
 > pip install -e .[dev,test]
 ```
 
-## Running the tests
+## Running The Tests
 
 First create a docker container with Postgres first.
 

--- a/docs/DevelopmentSetup.md
+++ b/docs/DevelopmentSetup.md
@@ -50,16 +50,35 @@ Once "pyenv" and "pyenv-virtualenv" have been installed, install Python 3.7.10:
 
 ## Running the tests
 
-To run the tests:
+First create a docker container with Postgres first.
+
+```
+> docker run -d -p 5432:5432 --name test -e POSTGRES_PASSWORD=password postgres
+```
+
+Then run pytest, which will run all test twice,
+with a Sqlite database and a Postgres database
 
 ```
 > pytest
 ```
 
-For running the test with Postgres, create a docker container with Postgres first.
+## Test Coverage Report
+
+A test coverage report can be generated using "pytest-cov":
+Note: create a docker container first as mentioned previously
+
 ```
-> docker run -d -p 5432:5432 --name test -e POSTGRES_PASSWORD=password postgres
+> pytest --cov=patsy tests/
 ```
+
+To generate an HTML report:
+
+```
+> pytest --cov-report html --cov=patsy tests/
+```
+
+The report will be written to the "htmlcov/" directory.
 
 ## Code Style
 
@@ -70,22 +89,6 @@ to check compliance with the guidelines can be run using:
 ```
 > pycodestyle .
 ```
-
-## Test Coverage Report
-
-A test coverage report can be generated using "pytest-cov":
-
-```
-> pytest --cov=patsy tests/
-```
-
-to generate an HTML report:
-
-```
-> pytest --cov-report html --cov=patsy tests/
-```
-
-The report will be written to the "htmlcov/" directory.
 
 ## Python Type Hinting
 

--- a/file.csv
+++ b/file.csv
@@ -1,0 +1,4 @@
+location
+libdc-archivebucket-17lowbw7m2av1/Archive000Florence/Florence.mpg
+libdc-archivebucket-17lowbw7m2av1/Archive000Football1/19461130-FB-002-2Qtr.mpg
+libdc-archivebucket-17lowbw7m2av1/Archive000Football1/19461130-FB-003-2Half.mpg

--- a/patsy/commands/schema.py
+++ b/patsy/commands/schema.py
@@ -16,6 +16,6 @@ def configure_cli(subparsers) -> None:  # type: ignore
 
 
 class Command(patsy.core.command.Command):
-    def __call__(self, args: argparse.Namespace, gateway: DbGateway) -> str:
+    def __call__(self, gateway: DbGateway) -> str:
         schema_impl = Schema(gateway)
         return schema_impl.create_schema()

--- a/patsy/core/load.py
+++ b/patsy/core/load.py
@@ -3,6 +3,7 @@ from patsy.core.db_gateway import DbGateway, AddResult
 from patsy.core.patsy_record import PatsyUtils
 from typing import Dict, List, Optional
 
+
 class LoadResult():
     def __init__(self) -> None:
         self.rows_processed = 0

--- a/patsy/core/load.py
+++ b/patsy/core/load.py
@@ -1,10 +1,7 @@
 import csv
-import logging 
 from patsy.core.db_gateway import DbGateway, AddResult
 from patsy.core.patsy_record import PatsyUtils
 from typing import Dict, List, Optional
-
-LOGGER = logging.getLogger('__name__')
 
 class LoadResult():
     def __init__(self) -> None:
@@ -57,7 +54,6 @@ class Load:
 
     def process_file(self, file: str) -> LoadResult:
         csv_line_index = 2  # Starting at two to account for CSV header
-        LOGGER.info("\n\n##########OPENING FILE##########\n\n")
         with open(file) as f:
             reader = csv.DictReader(f, delimiter=',')
             add_result = None

--- a/patsy/core/load.py
+++ b/patsy/core/load.py
@@ -1,8 +1,10 @@
 import csv
+import logging 
 from patsy.core.db_gateway import DbGateway, AddResult
 from patsy.core.patsy_record import PatsyUtils
 from typing import Dict, List, Optional
 
+LOGGER = logging.getLogger('__name__')
 
 class LoadResult():
     def __init__(self) -> None:
@@ -55,6 +57,7 @@ class Load:
 
     def process_file(self, file: str) -> LoadResult:
         csv_line_index = 2  # Starting at two to account for CSV header
+        LOGGER.info("\n\n##########OPENING FILE##########\n\n")
         with open(file) as f:
             reader = csv.DictReader(f, delimiter=',')
             add_result = None

--- a/patsy/core/schema.py
+++ b/patsy/core/schema.py
@@ -9,7 +9,7 @@ class Schema:
     def create_schema(self) -> str:
         session = self.gateway.session
         engine = session.get_bind()
-        #print("Creating the schema using the declarative base...")
+        # print("Creating the schema using the declarative base...")
         Base.metadata.create_all(engine)
 
         # Create "patsy_records" view

--- a/patsy/core/schema.py
+++ b/patsy/core/schema.py
@@ -9,7 +9,7 @@ class Schema:
     def create_schema(self) -> str:
         session = self.gateway.session
         engine = session.get_bind()
-        print("Creating the schema using the declarative base...")
+        #print("Creating the schema using the declarative base...")
         Base.metadata.create_all(engine)
 
         # Create "patsy_records" view

--- a/patsy/database.py
+++ b/patsy/database.py
@@ -21,7 +21,7 @@ def use_database_file(database: str) -> None:
     sys.stderr.write(str)
     sys.stderr.write("Binding the database session...")
 
-    engine = create_engine(db_path, echo=True)
+    engine = create_engine(db_path)#, echo=True)
 
     # Enable foreign key constraints
     if db_path.startswith('sqlite:'):

--- a/patsy/database.py
+++ b/patsy/database.py
@@ -1,11 +1,11 @@
-import argparse
 import sys
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
-from .model import Base
 
-Session = sessionmaker()#autocommit=True)
+
+Session = sessionmaker()
+
 
 def use_database_file(database: str) -> None:
     # Set up database file or use in-memory db
@@ -14,19 +14,18 @@ def use_database_file(database: str) -> None:
     else:
         db_path = f"sqlite:///{database}"
 
-    str = ("Using a transient in-memory database..." 
-            if database == (':memory:') 
-            else f"Using database at {database}...")
+    str = ("Using a transient in-memory database..."
+           if database == (':memory:')
+           else f"Using database at {database}...")
 
     sys.stderr.write(str)
     sys.stderr.write("Binding the database session...")
-
-    engine = create_engine(db_path)#, echo=True)
+    engine = create_engine(db_path)
 
     # Enable foreign key constraints
     if db_path.startswith('sqlite:'):
         event.listen(engine, 'connect',
-                        lambda dbapi_con, con_record:
-                            dbapi_con.execute('pragma foreign_keys=ON')) 
+                     lambda dbapi_con, con_record:
+                     dbapi_con.execute('pragma foreign_keys=ON'))
 
     Session.configure(bind=engine)

--- a/patsy/database.py
+++ b/patsy/database.py
@@ -3,34 +3,30 @@ import sys
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
-
 from .model import Base
 
-Session = sessionmaker()
-
+Session = sessionmaker()#autocommit=True)
 
 def use_database_file(database: str) -> None:
     # Set up database file or use in-memory db
-    if database == ":memory:":
-        sys.stderr.write(f"Using a transient in-memory database...")
-        db_path = f"sqlite:///{database}"
-
-    elif database.startswith('postgresql:'):
-        sys.stderr.write(f"Using postgres database at {database}")
+    if database.startswith('postgresql+psycopg2:'):
         db_path = database
-
     else:
-        sys.stderr.write(f"Using database at {database}...")
         db_path = f"sqlite:///{database}"
 
+    str = ("Using a transient in-memory database..." 
+            if database == (':memory:') 
+            else f"Using database at {database}...")
+
+    sys.stderr.write(str)
     sys.stderr.write("Binding the database session...")
 
-    engine = create_engine(db_path)
+    engine = create_engine(db_path, echo=True)
 
     # Enable foreign key constraints
-    if not db_path.startswith('postgresql:'):
+    if db_path.startswith('sqlite:'):
         event.listen(engine, 'connect',
-                     lambda dbapi_con, con_record:
-                         dbapi_con.execute('pragma foreign_keys=ON'))
+                        lambda dbapi_con, con_record:
+                            dbapi_con.execute('pragma foreign_keys=ON')) 
 
     Session.configure(bind=engine)

--- a/pytest.ini.hide
+++ b/pytest.ini.hide
@@ -1,0 +1,3 @@
+[pytest]
+log_cli = 1
+log_cli_level = INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sqlalchemy==1.3.13
+psycopg2==2.9.3

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
     python_requires='>=3.7',
     extras_require={  # Optional
        'dev': ['pycodestyle==2.7.0', 'mypy==0.910'],
-       'test': ['pytest==6.2.4', 'pytest-cov==2.12.1'],
+       'test': ['pytest==7.1.3', 'pytest-cov==2.12.1'],
     }
 )

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -58,8 +58,6 @@ def setUp(obj, addr):
     csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
     obj.load.process_file(csv_file)
 
-    
-
 
 class TestChecksumCommand:
     @patch('sys.stdout', new_callable=io.StringIO)

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 import unittest
 import logging
+import re
+import pytest
 
 from argparse import Namespace
 from patsy.commands.checksum import Command, get_checksum
@@ -17,157 +19,139 @@ LOGGER = logging.getLogger('__name__')
 from sqlalchemy.schema import DropTable
 from sqlalchemy.ext.compiler import compiles
 
-#https://stackoverflow.com/questions/38678336/sqlalchemy-how-to-implement-drop-table-cascade
-#https://docs.sqlalchemy.org/en/14/core/compiler.html#changing-compilation-of-types
+pytestmark = pytest.mark.parametrize("addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"])
+
 @compiles(DropTable, "postgresql")
 def _compile_drop_table(element, compiler, **kwargs):
     return compiler.visit_drop_table(element) + " CASCADE"
 
-class TestChecksumCommand(unittest.TestCase):
-    def setUp(self):
+def tearDown(obj):
+        obj.gateway.close()
+        Base.metadata.drop_all(obj.gateway.session.get_bind())
+
+def setUp(obj, addr):
         args = Namespace()
-        #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
-        self.gateway = DbGateway(args)
-    
-        #LOGGER.info("\n\n##########CREATING SCHEMA##########\n\n")
-        schema = Schema(self.gateway)
+        args.database = addr
+        obj.gateway = DbGateway(args)
+        schema = Schema(obj.gateway)
         schema.create_schema()
-
-        #LOGGER.info("\n\n##########LOADING##########\n\n")
-        self.load = Load(self.gateway)
-
-        #LOGGER.info("\n\n##########LOADING PROCESS FILE##########\n\n")
+        obj.load = Load(obj.gateway)
         csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
-        self.load.process_file(csv_file)
-        #LOGGER.info("\n\n##########FINISHED PROCESS FILE##########\n\n")
-
-        self.checksum_command = Command()
-        # Arguments passed to checksum.Command
-        self.command_args = Namespace()
-        self.command_args.location = None
-        self.command_args.output_type = None
-        self.command_args.output_file = None
-        #LOGGER.info("\n\n##########FINISHED SETUP##########\n\n")
-
-    @patch('sys.stdout', new_callable=io.StringIO)
-    def test_location_arg(self, mock_out):
-        self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
-
-        # The call command will write to a file
-        #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
-        self.checksum_command.__call__(self.command_args, self.gateway)
+        obj.load.process_file(csv_file)
         
-        # Compare the answer to what's written in file.
-        #LOGGER.info("\n\n###########COMPARING###########\n\n")
+        # Arguments passed to checksum.Command
+        obj.checksum_command = Command()
+        obj.command_args = Namespace()
+        obj.command_args.location = None
+        obj.command_args.output_type = None
+        obj.command_args.output_file = None
+        csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
+        obj.load.process_file(csv_file)
+
+class TestChecksumCommand:
+    
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_location_arg(self, mock_out, addr):
+        # The call command will write to a file
+        # and compare the answer to what's written in file.
+
+        setUp(self, addr)
+        self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
+        self.checksum_command.__call__(self.command_args, self.gateway)
+        LOGGER.info(f"{mock_out.getvalue()}")
         expected = '85a929103d2f58ddfa8c8768eb6339ad  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n'
-        self.assertEqual(expected, mock_out.getvalue())   
+        assert mock_out.getvalue() == expected
+        tearDown(self)
 
     @patch('sys.stdout', new_callable=io.StringIO)
-    def test_output_type_arg(self, mock_out):
+    def test_output_type_arg(self, mock_out, addr):
+        setUp(self, addr)
         self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
         self.command_args.output_type = 'sha1'
-        
-        #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
         self.checksum_command.__call__(self.command_args, self.gateway)
-
+        LOGGER.info(f"{mock_out.getvalue()}")
         expected = '2fa953a48600e1aef0486b4b3a17c6100cfeef80  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n'
-        #LOGGER.info("\n\n###########COMPARING###########\n\n")
-        self.assertEqual(expected, mock_out.getvalue())
+        assert mock_out.getvalue() == expected
+        tearDown(self)
 
     @patch('sys.stdout', new_callable=io.StringIO)
-    def test_locations_file_arg(self, mock_out):
+    def test_locations_file_arg(self, mock_out, addr):
+        setUp(self, addr)
         with open('tests/fixtures/checksum/locations_file.csv') as f:
             self.command_args.locations_file = f
-
-            #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
             self.checksum_command.__call__(self.command_args, self.gateway)
-
+            LOGGER.info(f"{mock_out.getvalue()}")
             expected = '85a929103d2f58ddfa8c8768eb6339ad  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n' \
                        '1041fd1cf84c71183db2d5d95942a41c  test_bucket/TEST_BATCH/colors/sample_red.jpg\n'
-            #LOGGER.info("\n\n###########COMPARING###########\n\n")
-            self.assertEqual(expected, mock_out.getvalue())
+            assert mock_out.getvalue() == expected
+        
+        tearDown(self)
 
-    def test_output_file_arg(self):
+    def test_output_file_arg(self, addr):
+        setUp(self, addr)
         with tempfile.TemporaryDirectory() as tmpdirname:
             output_filename = os.path.join(tmpdirname, 'test_output_file.csv')
             with open(output_filename, 'w') as output_file:
                 self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
                 self.command_args.output_file = output_file
-
-                #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
                 self.checksum_command.__call__(self.command_args, self.gateway)
 
-            #LOGGER.info("\n\n###########CHECKING SIZE###########\n\n")
-            self.assertEqual(80, os.path.getsize(output_filename))
+            assert os.path.getsize(output_filename) == 80
+        
+        tearDown(self)
     
-    def tearDown(self):
-        self.gateway.close()
-        Base.metadata.drop_all(self.gateway.session.get_bind())
+class TestGetChecksum:
 
-class TestGetChecksum(unittest.TestCase):
-    def setUp(self):
-        args = Namespace()
-        #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
-
-        self.gateway = DbGateway(args)
-        schema = Schema(self.gateway)
-        schema.create_schema()
-        self.load = Load(self.gateway)
-
-        csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
-
-        self.load.process_file(csv_file)
-
-    def test_valid_row_and_md5_checksum__returns_tuple(self):
+    def test_valid_row_and_md5_checksum__returns_tuple(self, addr):
+        setUp(self, addr)
         row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
         expected = ('85a929103d2f58ddfa8c8768eb6339ad', 'test_bucket/TEST_BATCH/colors/sample_blue.jpg')
-
         checksum_and_path = get_checksum(self.gateway, row, 'md5')
-        self.assertEqual(expected, checksum_and_path)
+        assert checksum_and_path == expected
+        tearDown(self)
 
-    def test_valid_row_and_sha1_checksum__returns_tuple(self):
+    def test_valid_row_and_sha1_checksum__returns_tuple(self, addr):
+        setUp(self, addr)
         row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
         expected = ('2fa953a48600e1aef0486b4b3a17c6100cfeef80', 'test_bucket/TEST_BATCH/colors/sample_blue.jpg')
-
         checksum_and_path = get_checksum(self.gateway, row, 'sha1')
-        self.assertEqual(expected, checksum_and_path)
+        assert checksum_and_path == expected
+        tearDown(self)
 
-    def test_gvalid_row_and_sha256_checksum__returns_tuple(self):
+    def test_gvalid_row_and_sha256_checksum__returns_tuple(self, addr):
+        setUp(self, addr)
         row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
         expected = (
             'e80dd1c34dbdc98521138eacc0e921683d8c9970a1f7cfe75bbfff56d5638238',
             'test_bucket/TEST_BATCH/colors/sample_blue.jpg'
         )
-
         checksum_and_path = get_checksum(self.gateway, row, 'sha256')
-        self.assertEqual(expected, checksum_and_path)
+        assert checksum_and_path == expected
+        tearDown(self)
 
     @patch('sys.stderr', new_callable=io.StringIO)
-    def test_location_not_found_returns__None_and_displays_error(self, mock_err):
+    def test_location_not_found_returns__None_and_displays_error(self, mock_err, addr):
+        setUp(self, addr)
         row = {'location': 'not_a_location_in_database'}
-
         checksum_and_path = get_checksum(self.gateway, row, 'md5')
-        self.assertIsNone(checksum_and_path)
-        self.assertRegex(mock_err.getvalue(), r"No accession record found for .*")
+        assert checksum_and_path == None
+        assert re.search(r"No accession record found for .*", mock_err.getvalue()) != None
+        tearDown(self)
 
     @patch('sys.stderr', new_callable=io.StringIO)
-    def test_checksum_type_not_found_returns__None_and_displays_error(self, mock_err):
+    def test_checksum_type_not_found_returns__None_and_displays_error(self, mock_err, addr):
+        setUp(self, addr)
         row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg'}
         checksum_type = 'invalid_type'
-
         checksum_and_path = get_checksum(self.gateway, row, checksum_type)
-        self.assertIsNone(checksum_and_path)
-        self.assertRegex(mock_err.getvalue(), r"No INVALID_TYPE checksum found .*")
+        assert checksum_and_path == None
+        assert re.search(r"No INVALID_TYPE checksum found .*", mock_err.getvalue()) != None
+        tearDown(self)
 
-    def test_tuple_contains_destination_if_provided(self):
+    def test_tuple_contains_destination_if_provided(self, addr):
+        setUp(self, addr)
         row = {'location': 'test_bucket/TEST_BATCH/colors/sample_blue.jpg', 'destination': 'DESTINATION'}
         expected = ('85a929103d2f58ddfa8c8768eb6339ad', 'DESTINATION')
-
         checksum_and_path = get_checksum(self.gateway, row, 'md5')
-        self.assertEqual(expected, checksum_and_path)
-
-    def tearDown(self):
-        self.gateway.close()
-        Base.metadata.drop_all(self.gateway.session.get_bind())
+        assert checksum_and_path == expected
+        tearDown(self)

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger('__name__')
 
 
 pytestmark = pytest.mark.parametrize(
-    "addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
+    "addr", [":memory"]  # , "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
 )
 
 

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -27,20 +27,20 @@ class TestChecksumCommand(unittest.TestCase):
     def setUp(self):
         args = Namespace()
         #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://aguilarm:aguilarm@localhost:5432/aguilarm"
+        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
         self.gateway = DbGateway(args)
     
-        LOGGER.info("\n\n##########CREATING SCHEMA##########\n\n")
+        #LOGGER.info("\n\n##########CREATING SCHEMA##########\n\n")
         schema = Schema(self.gateway)
         schema.create_schema()
 
-        LOGGER.info("\n\n##########LOADING##########\n\n")
+        #LOGGER.info("\n\n##########LOADING##########\n\n")
         self.load = Load(self.gateway)
 
-        LOGGER.info("\n\n##########LOADING PROCESS FILE##########\n\n")
+        #LOGGER.info("\n\n##########LOADING PROCESS FILE##########\n\n")
         csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
         self.load.process_file(csv_file)
-        LOGGER.info("\n\n##########FINISHED PROCESS FILE##########\n\n")
+        #LOGGER.info("\n\n##########FINISHED PROCESS FILE##########\n\n")
 
         self.checksum_command = Command()
         # Arguments passed to checksum.Command
@@ -48,18 +48,18 @@ class TestChecksumCommand(unittest.TestCase):
         self.command_args.location = None
         self.command_args.output_type = None
         self.command_args.output_file = None
-        LOGGER.info("\n\n##########FINISHED SETUP##########\n\n")
+        #LOGGER.info("\n\n##########FINISHED SETUP##########\n\n")
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_location_arg(self, mock_out):
         self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
 
         # The call command will write to a file
-        LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
+        #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
         self.checksum_command.__call__(self.command_args, self.gateway)
         
         # Compare the answer to what's written in file.
-        LOGGER.info("\n\n###########COMPARING###########\n\n")
+        #LOGGER.info("\n\n###########COMPARING###########\n\n")
         expected = '85a929103d2f58ddfa8c8768eb6339ad  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n'
         self.assertEqual(expected, mock_out.getvalue())   
 
@@ -68,11 +68,11 @@ class TestChecksumCommand(unittest.TestCase):
         self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
         self.command_args.output_type = 'sha1'
         
-        LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
+        #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
         self.checksum_command.__call__(self.command_args, self.gateway)
 
         expected = '2fa953a48600e1aef0486b4b3a17c6100cfeef80  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n'
-        LOGGER.info("\n\n###########COMPARING###########\n\n")
+        #LOGGER.info("\n\n###########COMPARING###########\n\n")
         self.assertEqual(expected, mock_out.getvalue())
 
     @patch('sys.stdout', new_callable=io.StringIO)
@@ -80,12 +80,12 @@ class TestChecksumCommand(unittest.TestCase):
         with open('tests/fixtures/checksum/locations_file.csv') as f:
             self.command_args.locations_file = f
 
-            LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
+            #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
             self.checksum_command.__call__(self.command_args, self.gateway)
 
             expected = '85a929103d2f58ddfa8c8768eb6339ad  test_bucket/TEST_BATCH/colors/sample_blue.jpg\n' \
                        '1041fd1cf84c71183db2d5d95942a41c  test_bucket/TEST_BATCH/colors/sample_red.jpg\n'
-            LOGGER.info("\n\n###########COMPARING###########\n\n")
+            #LOGGER.info("\n\n###########COMPARING###########\n\n")
             self.assertEqual(expected, mock_out.getvalue())
 
     def test_output_file_arg(self):
@@ -95,10 +95,10 @@ class TestChecksumCommand(unittest.TestCase):
                 self.command_args.location = ['test_bucket/TEST_BATCH/colors/sample_blue.jpg']
                 self.command_args.output_file = output_file
 
-                LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
+                #LOGGER.info("\n\n##########CALLING CHECKSUM###########\n\n")
                 self.checksum_command.__call__(self.command_args, self.gateway)
 
-            LOGGER.info("\n\n###########CHECKING SIZE###########\n\n")
+            #LOGGER.info("\n\n###########CHECKING SIZE###########\n\n")
             self.assertEqual(80, os.path.getsize(output_filename))
     
     def tearDown(self):
@@ -109,7 +109,7 @@ class TestGetChecksum(unittest.TestCase):
     def setUp(self):
         args = Namespace()
         #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://aguilarm:aguilarm@localhost:5432/aguilarm"
+        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
 
         self.gateway = DbGateway(args)
         schema = Schema(self.gateway)

--- a/tests/test_db_gateway.py
+++ b/tests/test_db_gateway.py
@@ -1,14 +1,20 @@
 import csv
 import unittest
-import logging
 from patsy.core.patsy_record import PatsyUtils
 from argparse import Namespace
 from patsy.core.schema import Schema
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
 from typing import Dict
+from patsy.model import Base
+from sqlalchemy.schema import DropTable
+from sqlalchemy.ext.compiler import compiles
 
-LOGGER = logging.getLogger('__name__')
+#https://stackoverflow.com/questions/38678336/sqlalchemy-how-to-implement-drop-table-cascade
+#https://docs.sqlalchemy.org/en/14/core/compiler.html#changing-compilation-of-types
+@compiles(DropTable, "postgresql")
+def _compile_drop_table(element, compiler, **kwargs):
+    return compiler.visit_drop_table(element) + " CASCADE"
 
 class TestDbGateway(unittest.TestCase):
     def setUp(self):
@@ -28,31 +34,25 @@ class TestDbGateway(unittest.TestCase):
             load.process_file(file)
 
     def test_get_all_batches(self):
-        LOGGER.info("\n ##########GETTING BATCHES##########\n")
         batches = self.gateway.get_all_batches()
 
-        LOGGER.info("\n ##########ASSERTING LENGTH##########\n")
         self.assertEqual(2, len(batches))
         batch_names = [batch.name for batch in batches]
 
-        LOGGER.info("\n ##########CHECKING NAMES##########\n")
         self.assertIn("TEST_COLORS", batch_names)
         self.assertIn("TEST_SOLAR_SYSTEM", batch_names)
 
     def test_get_batch_by_name__batch_does_not_exist(self):
         batch = self.gateway.get_batch_by_name("NON_EXISTENT_BATCH")
-        LOGGER.info("\n ##########ASSERTING BATCH DOESN'T EXIST##########\n")
         self.assertIsNone(batch)
 
     def test_get_batch_by_name__batch_exists(self):
         batch = self.gateway.get_batch_by_name("TEST_COLORS")
         self.assertIsNotNone(batch)
-        LOGGER.info("\n ##########ASSERTING BATCH EXIST##########\n")
         self.assertEqual("TEST_COLORS", batch.name)
 
     def test_get_batch_records__batch_does_not_exist(self):
         patsy_records = self.gateway.get_batch_records("NON_EXISTENT_BATCH")
-        LOGGER.info("\n ##########ASSERTING BATCH RECORD DOESN'T EXIST##########\n")
         self.assertEqual(0, len(patsy_records))
 
     def test_get_batch_records__batch_exists(self):
@@ -72,3 +72,4 @@ class TestDbGateway(unittest.TestCase):
     
     def tearDown(self):
         self.gateway.close()
+        Base.metadata.drop_all(self.gateway.session.get_bind())

--- a/tests/test_db_gateway.py
+++ b/tests/test_db_gateway.py
@@ -1,12 +1,14 @@
 import csv
-from patsy.core.patsy_record import PatsyUtils
 import unittest
+import logging
+from patsy.core.patsy_record import PatsyUtils
 from argparse import Namespace
 from patsy.core.schema import Schema
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
 from typing import Dict
 
+LOGGER = logging.getLogger('__name__')
 
 class TestDbGateway(unittest.TestCase):
     def setUp(self):
@@ -16,7 +18,8 @@ class TestDbGateway(unittest.TestCase):
         ]
 
         args = Namespace()
-        args.database = ":memory:"
+        #args.database = ":memory:"
+        args.database = "postgresql+psycopg2://aguilarm:aguilarm@localhost:5432/aguilarm"
         self.gateway = DbGateway(args)
         schema = Schema(self.gateway)
         schema.create_schema()
@@ -25,23 +28,31 @@ class TestDbGateway(unittest.TestCase):
             load.process_file(file)
 
     def test_get_all_batches(self):
+        LOGGER.info("\n ##########GETTING BATCHES##########\n")
         batches = self.gateway.get_all_batches()
+
+        LOGGER.info("\n ##########ASSERTING LENGTH##########\n")
         self.assertEqual(2, len(batches))
         batch_names = [batch.name for batch in batches]
+
+        LOGGER.info("\n ##########CHECKING NAMES##########\n")
         self.assertIn("TEST_COLORS", batch_names)
         self.assertIn("TEST_SOLAR_SYSTEM", batch_names)
 
     def test_get_batch_by_name__batch_does_not_exist(self):
         batch = self.gateway.get_batch_by_name("NON_EXISTENT_BATCH")
+        LOGGER.info("\n ##########ASSERTING BATCH DOESN'T EXIST##########\n")
         self.assertIsNone(batch)
 
     def test_get_batch_by_name__batch_exists(self):
         batch = self.gateway.get_batch_by_name("TEST_COLORS")
         self.assertIsNotNone(batch)
+        LOGGER.info("\n ##########ASSERTING BATCH EXIST##########\n")
         self.assertEqual("TEST_COLORS", batch.name)
 
     def test_get_batch_records__batch_does_not_exist(self):
         patsy_records = self.gateway.get_batch_records("NON_EXISTENT_BATCH")
+        LOGGER.info("\n ##########ASSERTING BATCH RECORD DOESN'T EXIST##########\n")
         self.assertEqual(0, len(patsy_records))
 
     def test_get_batch_records__batch_exists(self):
@@ -58,3 +69,6 @@ class TestDbGateway(unittest.TestCase):
 
         for p in patsy_records:
             self.assertIn(p, expected_patsy_records)
+    
+    def tearDown(self):
+        self.gateway.close()

--- a/tests/test_db_gateway.py
+++ b/tests/test_db_gateway.py
@@ -1,44 +1,49 @@
 import csv
 import pytest
 
-from patsy.core.patsy_record import PatsyUtils
 from argparse import Namespace
-from patsy.core.schema import Schema
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
-from typing import Dict
+from patsy.core.patsy_record import PatsyUtils
+from patsy.core.schema import Schema
 from patsy.model import Base
 from sqlalchemy.schema import DropTable
 from sqlalchemy.ext.compiler import compiles
 
-pytestmark = pytest.mark.parametrize("addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"])
+
+pytestmark = pytest.mark.parametrize(
+    "addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
+)
+
 
 @compiles(DropTable, "postgresql")
 def _compile_drop_table(element, compiler, **kwargs):
     return compiler.visit_drop_table(element) + " CASCADE"
 
-def setUp(obj, addr):
-        test_db_files = [
-            "tests/fixtures/db_gateway/colors_inventory.csv",
-            "tests/fixtures/db_gateway/solar_system_inventory.csv"
-        ]
 
-        args = Namespace()
-        args.database = addr
-        obj.gateway = DbGateway(args)
-        schema = Schema(obj.gateway)
-        schema.create_schema()
-        for file in test_db_files:
-            load = Load(obj.gateway)
-            load.process_file(file)
+def setUp(obj, addr):
+    test_db_files = [
+        "tests/fixtures/db_gateway/colors_inventory.csv",
+        "tests/fixtures/db_gateway/solar_system_inventory.csv"
+    ]
+
+    args = Namespace()
+    args.database = addr
+    obj.gateway = DbGateway(args)
+    schema = Schema(obj.gateway)
+    schema.create_schema()
+    for file in test_db_files:
+        load = Load(obj.gateway)
+        load.process_file(file)
+
 
 def tearDown(obj):
-        obj.gateway.close()
-        Base.metadata.drop_all(obj.gateway.session.get_bind())
+    obj.gateway.close()
+    Base.metadata.drop_all(obj.gateway.session.get_bind())
+
 
 class TestDbGateway:
-    
-    def test_get_all_batches(self,addr):
+    def test_get_all_batches(self, addr):
         setUp(self, addr)
         batches = self.gateway.get_all_batches()
         assert len(batches) == 2
@@ -47,26 +52,26 @@ class TestDbGateway:
         assert "TEST_SOLAR_SYSTEM" in batch_names
         tearDown(self)
 
-    def test_get_batch_by_name__batch_does_not_exist(self,addr):
+    def test_get_batch_by_name__batch_does_not_exist(self, addr):
         setUp(self, addr)
         batch = self.gateway.get_batch_by_name("NON_EXISTENT_BATCH")
-        assert batch == None
+        assert batch is None
         tearDown(self)
 
-    def test_get_batch_by_name__batch_exists(self,addr):
+    def test_get_batch_by_name__batch_exists(self, addr):
         setUp(self, addr)
         batch = self.gateway.get_batch_by_name("TEST_COLORS")
-        assert batch != None
+        assert batch is not None
         assert batch.name == "TEST_COLORS"
         tearDown(self)
 
-    def test_get_batch_records__batch_does_not_exist(self,addr):
+    def test_get_batch_records__batch_does_not_exist(self, addr):
         setUp(self, addr)
         patsy_records = self.gateway.get_batch_records("NON_EXISTENT_BATCH")
         assert len(patsy_records) == 0
         tearDown(self)
 
-    def test_get_batch_records__batch_exists(self,addr):
+    def test_get_batch_records__batch_exists(self, addr):
         setUp(self, addr)
         patsy_records = self.gateway.get_batch_records("TEST_COLORS")
         expected_patsy_records = []
@@ -74,10 +79,10 @@ class TestDbGateway:
             reader = csv.DictReader(f, delimiter=',')
             for row in reader:
                 expected_patsy_records.append(PatsyUtils.from_inventory_csv(row))
-        
+
         assert len(expected_patsy_records) >= 0
         assert len(expected_patsy_records) == len(patsy_records)
-        
+
         for p in patsy_records:
             assert p in expected_patsy_records
 

--- a/tests/test_db_gateway.py
+++ b/tests/test_db_gateway.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.compiler import compiles
 
 
 pytestmark = pytest.mark.parametrize(
-    "addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
+    "addr", [":memory"]  # , "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
 )
 
 

--- a/tests/test_db_gateway.py
+++ b/tests/test_db_gateway.py
@@ -2,18 +2,22 @@ import csv
 import pytest
 
 from argparse import Namespace
+from patsy.commands.schema import Command
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
 from patsy.core.patsy_record import PatsyUtils
-from patsy.core.schema import Schema
 from patsy.model import Base
 from sqlalchemy.schema import DropTable
 from sqlalchemy.ext.compiler import compiles
 
 
-pytestmark = pytest.mark.parametrize(
-    "addr", [":memory"]  # , "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
-)
+# pytestmark = pytest.mark.parametrize(
+#     "addr", [":memory"]  # , "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
+# )
+
+@pytest.fixture
+def addr(request):
+    return request.config.getoption('--base-url')
 
 
 @compiles(DropTable, "postgresql")
@@ -30,8 +34,9 @@ def setUp(obj, addr):
     args = Namespace()
     args.database = addr
     obj.gateway = DbGateway(args)
-    schema = Schema(obj.gateway)
-    schema.create_schema()
+    # schema = Schema(obj.gateway)
+    # schema.create_schema()
+    Command.__call__(obj, obj.gateway)
     for file in test_db_files:
         load = Load(obj.gateway)
         load.process_file(file)

--- a/tests/test_db_gateway.py
+++ b/tests/test_db_gateway.py
@@ -1,5 +1,6 @@
 import csv
-import unittest
+import pytest
+
 from patsy.core.patsy_record import PatsyUtils
 from argparse import Namespace
 from patsy.core.schema import Schema
@@ -10,66 +11,74 @@ from patsy.model import Base
 from sqlalchemy.schema import DropTable
 from sqlalchemy.ext.compiler import compiles
 
-#https://stackoverflow.com/questions/38678336/sqlalchemy-how-to-implement-drop-table-cascade
-#https://docs.sqlalchemy.org/en/14/core/compiler.html#changing-compilation-of-types
+pytestmark = pytest.mark.parametrize("addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"])
+
 @compiles(DropTable, "postgresql")
 def _compile_drop_table(element, compiler, **kwargs):
     return compiler.visit_drop_table(element) + " CASCADE"
 
-class TestDbGateway(unittest.TestCase):
-    def setUp(self):
+def setUp(obj, addr):
         test_db_files = [
             "tests/fixtures/db_gateway/colors_inventory.csv",
             "tests/fixtures/db_gateway/solar_system_inventory.csv"
         ]
 
         args = Namespace()
-        #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
-        self.gateway = DbGateway(args)
-        schema = Schema(self.gateway)
+        args.database = addr
+        obj.gateway = DbGateway(args)
+        schema = Schema(obj.gateway)
         schema.create_schema()
         for file in test_db_files:
-            load = Load(self.gateway)
+            load = Load(obj.gateway)
             load.process_file(file)
 
-    def test_get_all_batches(self):
+def tearDown(obj):
+        obj.gateway.close()
+        Base.metadata.drop_all(obj.gateway.session.get_bind())
+
+class TestDbGateway:
+    
+    def test_get_all_batches(self,addr):
+        setUp(self, addr)
         batches = self.gateway.get_all_batches()
-
-        self.assertEqual(2, len(batches))
+        assert len(batches) == 2
         batch_names = [batch.name for batch in batches]
+        assert "TEST_COLORS" in batch_names
+        assert "TEST_SOLAR_SYSTEM" in batch_names
+        tearDown(self)
 
-        self.assertIn("TEST_COLORS", batch_names)
-        self.assertIn("TEST_SOLAR_SYSTEM", batch_names)
-
-    def test_get_batch_by_name__batch_does_not_exist(self):
+    def test_get_batch_by_name__batch_does_not_exist(self,addr):
+        setUp(self, addr)
         batch = self.gateway.get_batch_by_name("NON_EXISTENT_BATCH")
-        self.assertIsNone(batch)
+        assert batch == None
+        tearDown(self)
 
-    def test_get_batch_by_name__batch_exists(self):
+    def test_get_batch_by_name__batch_exists(self,addr):
+        setUp(self, addr)
         batch = self.gateway.get_batch_by_name("TEST_COLORS")
-        self.assertIsNotNone(batch)
-        self.assertEqual("TEST_COLORS", batch.name)
+        assert batch != None
+        assert batch.name == "TEST_COLORS"
+        tearDown(self)
 
-    def test_get_batch_records__batch_does_not_exist(self):
+    def test_get_batch_records__batch_does_not_exist(self,addr):
+        setUp(self, addr)
         patsy_records = self.gateway.get_batch_records("NON_EXISTENT_BATCH")
-        self.assertEqual(0, len(patsy_records))
+        assert len(patsy_records) == 0
+        tearDown(self)
 
-    def test_get_batch_records__batch_exists(self):
+    def test_get_batch_records__batch_exists(self,addr):
+        setUp(self, addr)
         patsy_records = self.gateway.get_batch_records("TEST_COLORS")
-
         expected_patsy_records = []
         with open("tests/fixtures/db_gateway/colors_inventory.csv") as f:
             reader = csv.DictReader(f, delimiter=',')
             for row in reader:
                 expected_patsy_records.append(PatsyUtils.from_inventory_csv(row))
-
-        self.assertGreater(len(expected_patsy_records), 0)
-        self.assertEqual(len(expected_patsy_records), len(patsy_records))
-
+        
+        assert len(expected_patsy_records) >= 0
+        assert len(expected_patsy_records) == len(patsy_records)
+        
         for p in patsy_records:
-            self.assertIn(p, expected_patsy_records)
-    
-    def tearDown(self):
-        self.gateway.close()
-        Base.metadata.drop_all(self.gateway.session.get_bind())
+            assert p in expected_patsy_records
+
+        tearDown(self)

--- a/tests/test_db_gateway.py
+++ b/tests/test_db_gateway.py
@@ -25,7 +25,7 @@ class TestDbGateway(unittest.TestCase):
 
         args = Namespace()
         #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://aguilarm:aguilarm@localhost:5432/aguilarm"
+        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
         self.gateway = DbGateway(args)
         schema = Schema(self.gateway)
         schema.create_schema()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,12 +1,18 @@
 import unittest
-import logging
 from argparse import Namespace
 from patsy.core.schema import Schema
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
 from typing import Dict
+from patsy.model import Base
+from sqlalchemy.schema import DropTable
+from sqlalchemy.ext.compiler import compiles
 
-#LOGGER = logging.getLogger('__name__')
+#https://stackoverflow.com/questions/38678336/sqlalchemy-how-to-implement-drop-table-cascade
+#https://docs.sqlalchemy.org/en/14/core/compiler.html#changing-compilation-of-types
+@compiles(DropTable, "postgresql")
+def _compile_drop_table(element, compiler, **kwargs):
+    return compiler.visit_drop_table(element) + " CASCADE"
 
 class TestLoad(unittest.TestCase):
     def setUp(self):
@@ -148,7 +154,7 @@ class TestLoad(unittest.TestCase):
 
     def tearDown(self):
         self.gateway.close()
-
+        Base.metadata.drop_all(self.gateway.session.get_bind())
 
 def remove_key(dict: Dict[str, str], key: str) -> Dict[str, str]:
     new_dict = dict.copy()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -33,7 +33,7 @@ class TestLoad(unittest.TestCase):
 
         args = Namespace()
         #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://aguilarm:aguilarm@localhost:5432/aguilarm"
+        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
         self.gateway = DbGateway(args)
         schema = Schema(self.gateway)
         schema.create_schema()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -11,7 +11,7 @@ from typing import Dict
 
 
 pytestmark = pytest.mark.parametrize(
-    "addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
+    "addr", [":memory"]  # , "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
 )
 
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,6 @@
 import unittest
+import pytest
+
 from argparse import Namespace
 from patsy.core.schema import Schema
 from patsy.core.db_gateway import DbGateway
@@ -8,153 +10,172 @@ from patsy.model import Base
 from sqlalchemy.schema import DropTable
 from sqlalchemy.ext.compiler import compiles
 
-#https://stackoverflow.com/questions/38678336/sqlalchemy-how-to-implement-drop-table-cascade
-#https://docs.sqlalchemy.org/en/14/core/compiler.html#changing-compilation-of-types
+pytestmark = pytest.mark.parametrize("addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"])
+
 @compiles(DropTable, "postgresql")
 def _compile_drop_table(element, compiler, **kwargs):
     return compiler.visit_drop_table(element) + " CASCADE"
 
-class TestLoad(unittest.TestCase):
-    def setUp(self):
-        self.valid_row_dict = {
-            'BATCH': 'batch',
-            'RELPATH': 'relpath',
-            'FILENAME': 'filename',
-            'EXTENSION': 'extension',
-            'BYTES': 'bytes',
-            'MTIME': 'mtime',
-            'MODDATE': 'moddate',
-            'MD5': 'md5',
-            'SHA1': 'sha1',
-            'SHA256': 'sha256',
-            'storageprovider': 'storageprovider',
-            'storagepath': 'storagepath'
-        }
+def setUp(obj, addr):
+    obj.valid_row_dict = {
+        'BATCH': 'batch',
+        'RELPATH': 'relpath',
+        'FILENAME': 'filename',
+        'EXTENSION': 'extension',
+        'BYTES': 'bytes',
+        'MTIME': 'mtime',
+        'MODDATE': 'moddate',
+        'MD5': 'md5',
+        'SHA1': 'sha1',
+        'SHA256': 'sha256',
+        'storageprovider': 'storageprovider',
+        'storagepath': 'storagepath'
+    }
 
-        args = Namespace()
-        #args.database = ":memory:"
-        args.database = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
-        self.gateway = DbGateway(args)
-        schema = Schema(self.gateway)
-        schema.create_schema()
-        self.load = Load(self.gateway)
+    args = Namespace()
+    args.database = addr
+    obj.gateway = DbGateway(args)
+    schema = Schema(obj.gateway)
+    schema.create_schema()
+    obj.load = Load(obj.gateway)
 
-    def test_process_csv_file(self):
+def tearDown(obj):
+    obj.gateway.close()
+    Base.metadata.drop_all(obj.gateway.session.get_bind())
+
+class TestLoad():
+
+    def test_process_csv_file(self, addr):
+        setUp(self, addr)
         csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
-
         load_result = self.load.process_file(csv_file)
-        self.assertEqual(3, load_result.rows_processed)
+        assert load_result.rows_processed == 3
+        tearDown(self)
 
-    def test_is_row_valid__empty_dict(self):
+    def test_is_row_valid__empty_dict(self, addr):
+        setUp(self, addr)
         csv_line_index = 2
-
         row_dict = {}
-        self.assertFalse(self.load.is_row_valid(csv_line_index, row_dict))
+        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert len(self.load.load_result.errors) == 1
+        tearDown(self)
 
-        self.assertEqual(1, len(self.load.load_result.errors))
-
-    def test_is_row_valid__missing_required_field(self):
+    def test_is_row_valid__missing_required_field(self, addr):
+        setUp(self, addr)
         csv_line_index = 2
-
         row_dict = remove_key(self.valid_row_dict, 'BATCH')
-        self.assertFalse(self.load.is_row_valid(csv_line_index, row_dict))
-        self.assertEqual(1, len(self.load.load_result.errors))
+        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert len(self.load.load_result.errors) == 1
+        tearDown(self)
 
-    def test_is_row_valid__missing_allowed_empty_field(self):
+    def test_is_row_valid__missing_allowed_empty_field(self, addr):
+        setUp(self, addr)
         csv_line_index = 2
-
         row_dict = remove_key(self.valid_row_dict, 'SHA256')
-        self.assertFalse(self.load.is_row_valid(csv_line_index, row_dict))
-        self.assertEqual(1, len(self.load.load_result.errors))
+        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert len(self.load.load_result.errors) == 1
+        tearDown(self)
 
-    def test_is_row_valid__required_field_no_content(self):
+    def test_is_row_valid__required_field_no_content(self, addr):
+        setUp(self, addr)
         csv_line_index = 2
-
         row_dict = self.valid_row_dict.copy()
         row_dict['BATCH'] = ""
-        self.assertFalse(self.load.is_row_valid(csv_line_index, row_dict))
-        self.assertEqual(1, len(self.load.load_result.errors))
+        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert len(self.load.load_result.errors) == 1
+        tearDown(self)
 
-    def test_is_row_valid__allowed_missing_field_no_content(self):
+    def test_is_row_valid__allowed_missing_field_no_content(self, addr):
+        setUp(self, addr)
         csv_line_index = 2
-
         row_dict = self.valid_row_dict.copy()
         row_dict['SHA256'] = ""
-        self.assertTrue(self.load.is_row_valid(csv_line_index, row_dict))
-        self.assertEqual(0, len(self.load.load_result.errors))
+        assert self.load.is_row_valid(csv_line_index, row_dict) == True
+        assert len(self.load.load_result.errors) == 0
+        tearDown(self)
 
-    def test_load__file_with_invalid_rows(self):
+    def test_load__file_with_invalid_rows(self, addr):
+        setUp(self, addr)
         load_result = self.load.process_file('tests/fixtures/load/invalid_inventory.csv')
-        self.assertEqual(3, load_result.rows_processed)
-        self.assertEqual(1, load_result.batches_added)
-        self.assertEqual(2, load_result.accessions_added)
-        self.assertEqual(2, load_result.locations_added)
-        self.assertEqual(1, len(load_result.errors))
+        assert load_result.rows_processed == 3
+        assert load_result.batches_added == 1
+        assert load_result.accessions_added == 2
+        assert load_result.locations_added == 2
+        assert len(load_result.errors) == 1
+        tearDown(self)
 
-    def test_load__file_with_valid_rows(self):
+    def test_load__file_with_valid_rows(self, addr):
+        setUp(self, addr)
         load_result = self.load.process_file('tests/fixtures/load/colors_inventory-aws-archiver.csv')
-        self.assertEqual(3, load_result.rows_processed)
-        self.assertEqual(1, load_result.batches_added)
-        self.assertEqual(3, load_result.accessions_added)
-        self.assertEqual(3, load_result.locations_added)
-        self.assertEqual(0, len(load_result.errors))
+        assert load_result.rows_processed == 3
+        assert load_result.batches_added == 1
+        assert load_result.accessions_added == 3
+        assert load_result.locations_added == 3
+        assert len(load_result.errors) == 0
+        tearDown(self)
 
-    def test_load__file_with_multiple_accessions_one_location(self):
+    def test_load__file_with_multiple_accessions_one_location(self, addr):
+        setUp(self, addr)
         load_result = self.load.process_file('tests/fixtures/load/multiple_accessions_one_location.csv')
-        self.assertEqual(2, load_result.rows_processed)
-        self.assertEqual(2, load_result.batches_added)
-        self.assertEqual(2, load_result.accessions_added)
-        self.assertEqual(1, load_result.locations_added)
-        self.assertEqual(0, len(load_result.errors))
+        assert load_result.rows_processed == 2
+        assert load_result.batches_added == 2
+        assert load_result.accessions_added == 2
+        assert load_result.locations_added == 1
+        assert len(load_result.errors) == 0
+        tearDown(self)
 
-    def test_load__file_with_valid_rows_loaded_twice(self):
+    def test_load__file_with_valid_rows_loaded_twice(self, addr):
+        setUp(self, addr)
+
         # First load
         load_result = self.load.process_file('tests/fixtures/load/colors_inventory-aws-archiver.csv')
-        self.assertEqual(3, load_result.rows_processed)
-        self.assertEqual(1, load_result.batches_added)
-        self.assertEqual(3, load_result.accessions_added)
-        self.assertEqual(3, load_result.locations_added)
-        self.assertEqual(0, len(load_result.errors))
+        assert load_result.rows_processed == 3
+        assert load_result.batches_added == 1
+        assert load_result.accessions_added == 3
+        assert load_result.locations_added == 3
+        assert len(load_result.errors) == 0
 
         # Second load - nothing should be added
         self.load = Load(self.gateway)
         load_result = self.load.process_file('tests/fixtures/load/colors_inventory-aws-archiver.csv')
-        self.assertEqual(3, load_result.rows_processed)
-        self.assertEqual(0, load_result.batches_added)
-        self.assertEqual(0, load_result.accessions_added)
-        self.assertEqual(0, load_result.locations_added)
-        self.assertEqual(0, len(load_result.errors))
+        assert load_result.rows_processed == 3
+        assert load_result.batches_added == 0
+        assert load_result.accessions_added == 0
+        assert load_result.locations_added == 0
+        assert len(load_result.errors) == 0
+        tearDown(self)
 
-    def test_load__file_from_preserve_tool(self):
+    def test_load__file_from_preserve_tool(self, addr):
+        setUp(self, addr)
         load_result = self.load.process_file('tests/fixtures/load/colors_inventory-preserve.csv')
-        self.assertEqual(3, load_result.rows_processed)
-        self.assertEqual(1, load_result.batches_added)
-        self.assertEqual(3, load_result.accessions_added)
-        self.assertEqual(0, load_result.locations_added)
-        self.assertEqual(0, len(load_result.errors))
+        assert load_result.rows_processed == 3
+        assert load_result.batches_added == 1
+        assert load_result.accessions_added == 3
+        assert load_result.locations_added == 0
+        assert len(load_result.errors) == 0
+        tearDown(self)
 
-    def test_load__file_from_preserve_tool_then_archiver_update(self):
+    def test_load__file_from_preserve_tool_then_archiver_update(self, addr):
+        setUp(self, addr)
+
         # First load uses "preserve" file
         load_result = self.load.process_file('tests/fixtures/load/colors_inventory-preserve.csv')
-        self.assertEqual(3, load_result.rows_processed)
-        self.assertEqual(1, load_result.batches_added)
-        self.assertEqual(3, load_result.accessions_added)
-        self.assertEqual(0, load_result.locations_added)
-        self.assertEqual(0, len(load_result.errors))
+        assert load_result.rows_processed == 3
+        assert load_result.batches_added == 1
+        assert load_result.accessions_added == 3
+        assert load_result.locations_added == 0
+        assert len(load_result.errors) == 0
 
         # Second load updates the locations using the "asw-archiver" file,
         # only locations should be added.
         self.load = Load(self.gateway)
         load_result = self.load.process_file('tests/fixtures/load/colors_inventory-aws-archiver.csv')
-        self.assertEqual(3, load_result.rows_processed)
-        self.assertEqual(0, load_result.batches_added)
-        self.assertEqual(0, load_result.accessions_added)
-        self.assertEqual(3, load_result.locations_added)
-        self.assertEqual(0, len(load_result.errors))
-
-    def tearDown(self):
-        self.gateway.close()
-        Base.metadata.drop_all(self.gateway.session.get_bind())
+        assert load_result.rows_processed == 3
+        assert load_result.batches_added == 0
+        assert load_result.accessions_added == 0
+        assert load_result.locations_added == 3
+        assert len(load_result.errors) == 0
+        tearDown(self)
 
 def remove_key(dict: Dict[str, str], key: str) -> Dict[str, str]:
     new_dict = dict.copy()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,20 +1,24 @@
-import unittest
 import pytest
 
 from argparse import Namespace
 from patsy.core.schema import Schema
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
-from typing import Dict
 from patsy.model import Base
 from sqlalchemy.schema import DropTable
 from sqlalchemy.ext.compiler import compiles
+from typing import Dict
 
-pytestmark = pytest.mark.parametrize("addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"])
+
+pytestmark = pytest.mark.parametrize(
+    "addr", [":memory", "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
+)
+
 
 @compiles(DropTable, "postgresql")
 def _compile_drop_table(element, compiler, **kwargs):
     return compiler.visit_drop_table(element) + " CASCADE"
+
 
 def setUp(obj, addr):
     obj.valid_row_dict = {
@@ -39,12 +43,13 @@ def setUp(obj, addr):
     schema.create_schema()
     obj.load = Load(obj.gateway)
 
+
 def tearDown(obj):
     obj.gateway.close()
     Base.metadata.drop_all(obj.gateway.session.get_bind())
 
-class TestLoad():
 
+class TestLoad():
     def test_process_csv_file(self, addr):
         setUp(self, addr)
         csv_file = 'tests/fixtures/load/colors_inventory-aws-archiver.csv'
@@ -56,7 +61,7 @@ class TestLoad():
         setUp(self, addr)
         csv_line_index = 2
         row_dict = {}
-        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert self.load.is_row_valid(csv_line_index, row_dict) is False
         assert len(self.load.load_result.errors) == 1
         tearDown(self)
 
@@ -64,7 +69,7 @@ class TestLoad():
         setUp(self, addr)
         csv_line_index = 2
         row_dict = remove_key(self.valid_row_dict, 'BATCH')
-        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert self.load.is_row_valid(csv_line_index, row_dict) is False
         assert len(self.load.load_result.errors) == 1
         tearDown(self)
 
@@ -72,7 +77,7 @@ class TestLoad():
         setUp(self, addr)
         csv_line_index = 2
         row_dict = remove_key(self.valid_row_dict, 'SHA256')
-        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert self.load.is_row_valid(csv_line_index, row_dict) is False
         assert len(self.load.load_result.errors) == 1
         tearDown(self)
 
@@ -81,7 +86,7 @@ class TestLoad():
         csv_line_index = 2
         row_dict = self.valid_row_dict.copy()
         row_dict['BATCH'] = ""
-        assert self.load.is_row_valid(csv_line_index, row_dict) == False
+        assert self.load.is_row_valid(csv_line_index, row_dict) is False
         assert len(self.load.load_result.errors) == 1
         tearDown(self)
 
@@ -90,7 +95,7 @@ class TestLoad():
         csv_line_index = 2
         row_dict = self.valid_row_dict.copy()
         row_dict['SHA256'] = ""
-        assert self.load.is_row_valid(csv_line_index, row_dict) == True
+        assert self.load.is_row_valid(csv_line_index, row_dict) is True
         assert len(self.load.load_result.errors) == 0
         tearDown(self)
 
@@ -176,6 +181,7 @@ class TestLoad():
         assert load_result.locations_added == 3
         assert len(load_result.errors) == 0
         tearDown(self)
+
 
 def remove_key(dict: Dict[str, str], key: str) -> Dict[str, str]:
     new_dict = dict.copy()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,10 +1,12 @@
 import unittest
+import logging
 from argparse import Namespace
 from patsy.core.schema import Schema
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
 from typing import Dict
 
+#LOGGER = logging.getLogger('__name__')
 
 class TestLoad(unittest.TestCase):
     def setUp(self):
@@ -24,7 +26,8 @@ class TestLoad(unittest.TestCase):
         }
 
         args = Namespace()
-        args.database = ":memory:"
+        #args.database = ":memory:"
+        args.database = "postgresql+psycopg2://aguilarm:aguilarm@localhost:5432/aguilarm"
         self.gateway = DbGateway(args)
         schema = Schema(self.gateway)
         schema.create_schema()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,7 +1,7 @@
 import pytest
 
 from argparse import Namespace
-from patsy.core.schema import Schema
+from patsy.commands.schema import Command
 from patsy.core.db_gateway import DbGateway
 from patsy.core.load import Load
 from patsy.model import Base
@@ -10,9 +10,14 @@ from sqlalchemy.ext.compiler import compiles
 from typing import Dict
 
 
-pytestmark = pytest.mark.parametrize(
-    "addr", [":memory"]  # , "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
-)
+# pytestmark = pytest.mark.parametrize(
+#     "addr", [":memory"]  # , "postgresql+psycopg2://postgres:password@localhost:5432/postgres"]
+# )
+
+
+@pytest.fixture
+def addr(request):
+    return request.config.getoption('--base-url')
 
 
 @compiles(DropTable, "postgresql")
@@ -39,8 +44,9 @@ def setUp(obj, addr):
     args = Namespace()
     args.database = addr
     obj.gateway = DbGateway(args)
-    schema = Schema(obj.gateway)
-    schema.create_schema()
+    # schema = Schema(obj.gateway)
+    # schema.create_schema()
+    Command.__call__(obj, obj.gateway)
     obj.load = Load(obj.gateway)
 
 


### PR DESCRIPTION
Changed Tests to Support Postgres
- Removed usage of unittest for just pytest because of interference with Pytest features that couldn't be used alongside unittest
- Added Documentation for running docker containers with postgres before running pytest
- Updated Pytest to 7.1.3 to use global fixture markers

Created Jenkinsfile and Dockerfile.ci so that tests can be run automatically after pull requests.
- Commented tests files to not run the tests on a postgres database temporarily, until Jenkins is setup to be able to run Postgres


https://issues.umd.edu/browse/LIBITD-1754