### PR TITLE
LIBITD-2228. Added Environment Variable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ run against.
 For SQLite databases, this is typically the filename of the SQLite database
 file.
 
+The "--database" argument can be ommited if the user specifies a database to
+connect to as an environment variable. The environment variable must be named
+"PATSY_DATABASE".
+
+```
+> export PATSY_DATABASE={database url}
+```
+
+The "--database" argument can still be passed in to override the environment
+variable temporarily.
+
 ### "schema" command
 
 Creates the database schema.

--- a/patsy/__main__.py
+++ b/patsy/__main__.py
@@ -74,7 +74,7 @@ def main() -> None:
             sys.stderr.write(result)
             sys.stderr.write('\n\n')
     except DatabaseNotSetError:
-        sys.stderr.write('Database not set. Either supply the "-d" argument to this command or set the "PATSY_DATABASE" environment variable.')
+        sys.stderr.write('The "-d" argument was not set nor was the "PATSY_DATABASE" environment variable.')
         # exit with a non-zero code to indicate to the shell that the command failed to run
         sys.exit(1)
 

--- a/patsy/__main__.py
+++ b/patsy/__main__.py
@@ -36,9 +36,9 @@ def main() -> None:
 
     parser.add_argument(
         '-d', '--database',
-        default=':memory:',
+        default=None,
         action='store',
-        help='Path to db file (defaults to in-memory db)',
+        help='Path to db file (defaults to None)',
     )
 
     subparsers = parser.add_subparsers(title='commands')

--- a/patsy/database.py
+++ b/patsy/database.py
@@ -8,6 +8,10 @@ from sqlalchemy.orm import sessionmaker
 Session = sessionmaker()
 
 
+class DatabaseNotSetError(Exception):
+    pass
+
+
 def use_database_file(database) -> None:
     envDatabase = os.getenv('PATSY_DATABASE')
     if database is not None:
@@ -15,7 +19,7 @@ def use_database_file(database) -> None:
     elif envDatabase is not None:
         database_helper(envDatabase)
     else:
-        raise Exception("Database not given and no environment variable set")
+        raise DatabaseNotSetError
 
 
 def database_helper(database: str) -> None:

--- a/patsy/database.py
+++ b/patsy/database.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
@@ -7,7 +8,17 @@ from sqlalchemy.orm import sessionmaker
 Session = sessionmaker()
 
 
-def use_database_file(database: str) -> None:
+def use_database_file(database) -> None:
+    envDatabase = os.getenv('PATSY_DATABASE')
+    if database is not None:
+        database_helper(database)
+    elif envDatabase is not None:
+        database_helper(envDatabase)
+    else:
+        raise Exception("Database not given and no environment variable set")
+
+
+def database_helper(database: str) -> None:
     # Set up database file or use in-memory db
     if database.startswith('postgresql+psycopg2:'):
         db_path = database


### PR DESCRIPTION
Patsy can now use an environment variable set in the shell session. The -d option has been changed to default to None now.

https://issues.umd.edu/browse/LIBITD-2228