### PR TITLE
LIBITD-2487. Fix Jenkinsfile for Jenkins v2.440.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ pipeline {
         always {
           junit '**/reports/results.xml'
 
-          cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, zoomCoverageChart: false
+          recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'reports/coverage.xml']])
         }
       }
     }
@@ -137,7 +137,9 @@ pipeline {
       post {
         always {
           // Collect pycodestyle reports
-          recordIssues(tools: [pyLint(reportEncoding: 'UTF-8', name: 'pycodestyle')], unstableTotalAll: 1)
+          recordIssues(tools: [pyLint(reportEncoding: 'UTF-8', name: 'pycodestyle')],
+                       qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']]
+          )
         }
       }
     }


### PR DESCRIPTION
Updated the "recordIssues" directive in the "Jenkinsfile" to use the "qualityGates" parameter, instead of the obsolete "unstableTotalAll" parameter.

Replaced obsolete "cobertura" directive in the "Jenkinsfile" with "recordCoverage" directive

https://umd-dit.atlassian.net/browse/LIBITD-2487